### PR TITLE
MacOS compatibility (X-Platform) 👽 

### DIFF
--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -26,13 +26,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            configure_preset: linux-ci
-            preset: linux-ci
-          - os: windows-latest
-            configure_preset: windows-ci
-            preset: windows-ci-debug
+          include:
+            - os: ubuntu-latest
+              configure_preset: linux-ci
+              preset: linux-ci
+            - os: windows-latest
+              configure_preset: windows-ci
+              preset: windows-ci-debug
+            - os: macos-latest
+              configure_preset: macos-ci
+              preset: macos-ci
 
     steps:
       - name: Checkout
@@ -51,6 +54,10 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: ./scripts/install-deps.ps1
+
+      - name: Install dependencies on macOS
+        if: runner.os == 'macOS'
+        run: bash scripts/install-deps.sh
 
       - name: Configure
         run: cmake --preset ${{ matrix.configure_preset }}

--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -26,16 +26,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          include:
-            - os: ubuntu-latest
-              configure_preset: linux-ci
-              preset: linux-ci
-            - os: windows-latest
-              configure_preset: windows-ci
-              preset: windows-ci-debug
-            - os: macos-latest
-              configure_preset: macos-ci
-              preset: macos-ci
+        include:
+          - os: ubuntu-latest
+            configure_preset: linux-ci
+            preset: linux-ci
+          - os: windows-latest
+            configure_preset: windows-ci
+            preset: windows-ci-debug
+          - os: macos-latest
+            configure_preset: macos-ci
+            preset: macos-ci
 
     steps:
       - name: Checkout

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -92,6 +92,39 @@
                 "ASGE_BUILD_EXAMPLES": "OFF",
                 "ASGE_INSTALL": "ON"
             }
+        },
+        {
+            "name": "macos-base",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/build",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        },
+        {
+            "name": "macos",
+            "displayName": "macOS (dev: tests + examples)",
+            "description": "Single-config generator, so CMAKE_BUILD_TYPE is fixed to Debug here for the local dev loop.",
+            "inherits": "macos-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "SDL3_DIR": "/opt/homebrew/lib/cmake/SDL3",
+                "BUILD_TESTING": "ON",
+                "ASGE_BUILD_EXAMPLES": "ON"
+            }
+        },
+        {
+            "name": "macos-ci",
+            "displayName": "macOS (CI parity)",
+            "description": "Mirrors a macOS CI job exactly (no explicit CMAKE_BUILD_TYPE, examples off).",
+            "inherits": "macos-base",
+            "cacheVariables": {
+                "SDL3_DIR": "/opt/homebrew/lib/cmake/SDL3",
+                "BUILD_TESTING": "ON",
+                "ASGE_BUILD_EXAMPLES": "OFF"
+            }
         }
     ],
     "buildPresets": [
@@ -126,6 +159,14 @@
             "name": "windows-package",
             "configurePreset": "windows-package",
             "configuration": "Release"
+        },
+        {
+            "name": "macos",
+            "configurePreset": "macos"
+        },
+        {
+            "name": "macos-ci",
+            "configurePreset": "macos-ci"
         }
     ],
     "testPresets": [
@@ -155,6 +196,20 @@
         {
             "name": "linux-ci",
             "configurePreset": "linux-ci",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "macos",
+            "configurePreset": "macos",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "macos-ci",
+            "configurePreset": "macos-ci",
             "output": {
                 "outputOnFailure": true
             }

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -6,5 +6,12 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # Single entry point for CI/devs to fetch every vendored third-party
 # dependency. Add new dependencies here rather than wiring them into CI
 # workflows individually.
-bash "${repo_root}/scripts/install-sdl-linux.sh"
+case "$(uname -s)" in
+    Darwin)
+        bash "${repo_root}/scripts/install-sdl-mac.sh"
+        ;;
+    *)
+        bash "${repo_root}/scripts/install-sdl-linux.sh"
+        ;;
+esac
 bash "${repo_root}/scripts/install-stb.sh"

--- a/scripts/install-sdl-mac.sh
+++ b/scripts/install-sdl-mac.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# On macOS SDL3 is installed via Homebrew rather than built from source.
+# The stb single-header libraries are fetched separately by install-stb.sh.
+command -v brew >/dev/null 2>&1 || {
+    echo "brew not found on PATH. Install Homebrew (https://brew.sh) and re-run." >&2
+    exit 1
+}
+
+brew install sdl3

--- a/src/ASGE/CMakeLists.txt
+++ b/src/ASGE/CMakeLists.txt
@@ -68,6 +68,9 @@ add_library(ASGE::ASGE ALIAS ASGE)
 
 target_link_libraries(ASGE PUBLIC SDL3::SDL3)
 target_link_libraries(ASGE PRIVATE stb::stb)
+if(APPLE)
+    target_link_libraries(ASGE PRIVATE "-framework CoreServices")
+endif()
 target_include_directories(ASGE
     PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>"

--- a/src/ASGE/Core/Configuration/ConfigurationManager.cpp
+++ b/src/ASGE/Core/Configuration/ConfigurationManager.cpp
@@ -19,7 +19,7 @@ asge::BoolResult asge::config::ConfigurationManager::ReadConfiguration( filesyst
         return BoolResult::Err( result.Error() );
     }
 
-    m_Configuration.store(std::move(result.Value()), std::memory_order_release);
+    m_Configuration = std::move(result.Value());
     return BoolResult::Ok();
 }
 
@@ -127,7 +127,7 @@ asge::BoolResult asge::config::ConfigurationManager::Save()
 {
     std::lock_guard<std::mutex> lock( m_ConfigMutex );
 
-    auto cfg = m_Configuration.load( std::memory_order_acquire );
+    auto cfg = m_Configuration;
     if ( !cfg )
     {
         return BoolResult::Err( make_error_code( errors::ConfError::ConfigurationNotLoaded ) );

--- a/src/ASGE/Core/Configuration/ConfigurationManager.hpp
+++ b/src/ASGE/Core/Configuration/ConfigurationManager.hpp
@@ -22,7 +22,7 @@ private:
     filesystem::Path             m_ConfigPath;
     filesystem::FileWatcher      m_FileWatcher;
     filesystem::WatcherHandler   m_WatcherConnection;
-    std::atomic<table_pointer_t> m_Configuration{ nullptr };
+    table_pointer_t              m_Configuration{ nullptr };
     std::atomic<bool>            m_HotReloadEnabled{ false };
 
     // Guards Get/Set/Save against each other and against a hot-reload swap.
@@ -50,7 +50,7 @@ public:
     {
         std::lock_guard<std::mutex> lock( m_ConfigMutex );
 
-        auto cfg = m_Configuration.load( std::memory_order_acquire );
+        auto cfg = m_Configuration;
         if ( !cfg )
         {
             return Result<T>::Err( make_error_code( errors::ConfError::ConfigurationNotLoaded ) );
@@ -75,7 +75,7 @@ public:
     {
         std::lock_guard<std::mutex> lock( m_ConfigMutex );
 
-        auto cfg = m_Configuration.load( std::memory_order_acquire );
+        auto cfg = m_Configuration;
         if ( !cfg )
         {
             return BoolResult::Err( make_error_code( errors::ConfError::ConfigurationNotLoaded ) );

--- a/src/ASGE/Core/Filesystem/FileWatcher.cpp
+++ b/src/ASGE/Core/Filesystem/FileWatcher.cpp
@@ -431,6 +431,182 @@ asge::Result<WatcherHandler> asge::filesystem::_win32::FileWatcher::AddWatch(
     }
 }
 
+#elif defined(__APPLE__)
+
+FEventType asge::filesystem::_apple::FileWatcher::MapEvent( FSEventStreamEventFlags inFlags ) noexcept
+{
+    // FSEvents flags are cumulative, so a single write can carry
+    // kFSEventStreamEventFlagItemCreated | kFSEventStreamEventFlagItemModified
+    // at once. Check Modified before Created so an in-place edit maps to
+    // Modified (not Created), which the consumer's event mask expects.
+    if ( inFlags & kFSEventStreamEventFlagItemModified ) return FEventType::Modified;
+    if ( inFlags & kFSEventStreamEventFlagItemCreated ) return FEventType::Created;
+    if ( inFlags & kFSEventStreamEventFlagItemRemoved ) return FEventType::Deleted;
+    return FEventType::None;
+}
+
+asge::BoolResult asge::filesystem::_apple::FileWatcher::RegisterNewWatch(path_type inPath) noexcept
+{
+    std::lock_guard<std::mutex> lock( m_WatchesMtx );
+
+    if ( m_WatchedStreams.find( inPath ) != m_WatchedStreams.end() ) return BoolResult::Ok();
+
+    std::string u8_path = str::ToUTF8( inPath.u8string() );
+    CFStringRef cfPath = CFStringCreateWithCString( kCFAllocatorDefault, u8_path.c_str(), kCFStringEncodingUTF8 );
+    if ( cfPath == nullptr ) {
+        return BoolResult::Err( MakeErrorFromErrno(), u8_path );
+    }
+
+    CFTypeRef items[1] = { cfPath };
+    CFArrayRef pathsToWatch = CFArrayCreate( kCFAllocatorDefault, items, 1, &kCFTypeArrayCallBacks );
+
+    FSEventStreamContext ctx{ 0 };
+    ctx.info = this;
+
+    FSEventStreamRef stream = FSEventStreamCreate(
+        kCFAllocatorDefault,
+        &OnFSEventStream,
+        &ctx,
+        pathsToWatch,
+        kFSEventStreamEventIdSinceNow,
+        0.0,
+        kFSEventStreamCreateFlagFileEvents
+    );
+
+    CFRelease( cfPath );
+    CFRelease( pathsToWatch );
+
+    if ( stream == nullptr ) {
+        return BoolResult::Err( MakeErrorFromErrno(), u8_path );
+    }
+
+    // FSEvents can only deliver events after the stream is scheduled
+    // on a dispatch queue or run loop; start without one silently fails.
+    dispatch_queue_t queue = dispatch_queue_create( "asge.filewatcher", DISPATCH_QUEUE_SERIAL );
+    FSEventStreamSetDispatchQueue( stream, queue );
+
+    if ( !FSEventStreamStart( stream ) )
+    {
+        FSEventStreamSetDispatchQueue( stream, nullptr );
+        ::FSEventStreamInvalidate( stream );
+        ::FSEventStreamRelease( stream );
+        dispatch_release( queue );
+        return BoolResult::Err( MakeErrorFromErrno(), u8_path );
+    }
+
+    m_WatchedStreams.emplace( inPath, FSEventEntry{ stream, queue } );
+    return BoolResult::Ok();
+}
+
+void asge::filesystem::_apple::FileWatcher::OnFSEventStream(
+    ConstFSEventStreamRef inStream,
+    void* inInfo,
+    std::size_t inNumEvents,
+    void* inEventPaths,
+    FSEventStreamEventFlags const* inEventFlags,
+    FSEventStreamEventId const* inEventIds
+)
+{
+    (void)inStream;
+    (void)inEventIds;
+
+    auto* self = static_cast< _apple::FileWatcher* >( inInfo );
+    auto const* paths = static_cast< char const* const* >( inEventPaths );
+    for ( std::size_t ii = 0; ii < inNumEvents; ++ii )
+    {
+        FEventType type = MapEvent( inEventFlags[ii] );
+        if ( type == FEventType::None ) continue;
+
+        auto const& event = FileEvent::CreateFileEvent(
+            path_type( paths[ii] ),
+            type,
+            inEventFlags[ii],
+            /* inOldPath */ ""
+        );
+        self->m_OnEvent.Emit( event );
+    }
+}
+
+void asge::filesystem::_apple::FileWatcher::Run( concurrent::context_pointer& inCtx )
+{
+    // FSEvents delivers callbacks on its own thread, so the watcher
+    // thread just has to stay alive until the caller cancels it.
+    inCtx->Wait();
+}
+
+asge::filesystem::_apple::FileWatcher::FileWatcher()
+: FileWatcher( nullptr )
+{}
+
+asge::filesystem::_apple::FileWatcher::FileWatcher( concurrent::context_pointer inCtx )
+: concurrent::Thread( "FileWatcher", inCtx )
+{}
+
+asge::filesystem::_apple::FileWatcher::~FileWatcher()
+{
+    Cancel();
+    Join();
+
+    std::lock_guard<std::mutex> lock( m_WatchesMtx );
+    for ( auto const& entry : m_WatchedStreams )
+    {
+        ::FSEventStreamSetDispatchQueue( entry.second.s_Stream, nullptr );
+        ::FSEventStreamInvalidate( entry.second.s_Stream );
+        ::FSEventStreamRelease( entry.second.s_Stream );
+        dispatch_release( entry.second.s_Queue );
+    }
+    m_WatchedStreams.clear();
+}
+
+asge::Result<WatcherHandler> asge::filesystem::_apple::FileWatcher::AddWatch(
+    path_type inPath, _internal::callback_type_cref inCallback, mask_type inMask
+)
+{
+    if ( !meta::Exists( inPath ) )
+    {
+        auto const ec = std::make_error_code( std::errc::no_such_file_or_directory );
+        return asge::Result<WatcherHandler>::Err( ec, str::ToUTF8( inPath.u8string() ) );
+    }
+
+    if ( meta::IsDirectory( inPath ) )
+    {
+        auto connector = m_OnEvent.Connect( _internal::CreateCallback( inCallback, inMask ) );
+        if ( auto result = RegisterNewWatch( inPath ); !result ) {
+            connector.Disconnect();
+            return Result<WatcherHandler>::Err( result.Error() );
+        }
+
+        LOG_INFO( "Added new watch for ", inPath, " with mask ", inMask );
+        return Result<WatcherHandler>::Ok( connector );
+    }
+
+    inPath = inPath.lexically_normal();
+    path_type parentPath = inPath.parent_path();
+
+    // FSEvents reports the canonical (symlink-resolved) path — e.g.
+    // /private/var/... for a /var/... target — so compare on canonical paths.
+    // weakly_canonical does not throw if the path no longer exists.
+    auto canonical = []( path_type const& p ) {
+        std::error_code ec;
+        return std::filesystem::weakly_canonical( p, ec );
+    };
+    path_type watchTarget = canonical( inPath );
+    auto filtered = [ inCallback, watchTarget, canonical ]( FileEvent const& e ) {
+        if ( !e.IsDir() && canonical( e.s_Path ) == watchTarget ) inCallback( e );
+    };
+
+    // Connect the listener before starting the stream so FSEvents' initial
+    // batch (delivered at start) is not lost because nothing is listening.
+    auto connector = m_OnEvent.Connect( _internal::CreateCallback( filtered, inMask ) );
+    if ( auto result = RegisterNewWatch( parentPath ); !result ) {
+        connector.Disconnect();
+        return Result<WatcherHandler>::Err( result.Error() );
+    }
+
+    LOG_INFO( "Added new watch for ", inPath, " with mask ", inMask );
+    return Result<WatcherHandler>::Ok( connector );
+}
+
 #else
 
 bool asge::filesystem::_linux::FileWatcher::isValid() const noexcept

--- a/src/ASGE/Core/Filesystem/FileWatcher.hpp
+++ b/src/ASGE/Core/Filesystem/FileWatcher.hpp
@@ -24,6 +24,10 @@
 #ifdef _WIN32
 #include <windows.h>
 #define INVALID_FD INVALID_HANDLE_VALUE
+#elif defined(__APPLE__)
+#include <CoreServices/CoreServices.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <dispatch/dispatch.h>
 #else
 #include <sys/inotify.h>
 #include <sys/epoll.h>
@@ -61,6 +65,8 @@ std::ostream& operator<<( std::ostream& inOss, FEventType inMask ) noexcept;
 #ifdef _WIN32
 using native_event_t = DWORD;
 using handle_t = HANDLE;
+#elif defined(__APPLE__)
+using native_event_t = std::uint32_t;
 #else
 using native_event_t = std::uint32_t;
 using handle_t = std::int32_t;
@@ -173,6 +179,55 @@ public:
 
 }
 using FileWatcher = _win32::FileWatcher;
+#elif defined(__APPLE__)
+namespace _apple
+{
+
+class FileWatcher : public concurrent::Thread
+{
+public:
+    using path_type = Path;
+    using mask_type = FEventType;
+
+private:
+    struct FSEventEntry
+    {
+        FSEventStreamRef s_Stream;
+        dispatch_queue_t s_Queue;
+    };
+
+    mutable std::mutex m_WatchesMtx;
+    std::unordered_map<path_type, FSEventEntry, PathHash> m_WatchedStreams;
+
+    signals::Signal<FileEvent const&> m_OnEvent;
+
+    static FEventType MapEvent( FSEventStreamEventFlags inFlags ) noexcept;
+    BoolResult RegisterNewWatch( path_type inPath ) noexcept;
+
+    static void OnFSEventStream(
+        ConstFSEventStreamRef inStream,
+        void* inInfo,
+        std::size_t inNumEvents,
+        void* inEventPaths,
+        FSEventStreamEventFlags const* inEventFlags,
+        FSEventStreamEventId const* inEventIds
+    );
+
+    void Run( concurrent::context_pointer& inCtx ) override;
+
+public:
+    FileWatcher();
+    FileWatcher(concurrent::context_pointer inCtx);
+    ~FileWatcher();
+
+    Result<WatcherHandler> AddWatch( path_type inPath,
+        _internal::callback_type_cref inCallback,
+        mask_type inMask = mask_type::All
+    );
+};
+
+}
+using FileWatcher = _apple::FileWatcher;
 #else
 namespace _linux
 {

--- a/src/ASGE/Core/Filesystem/FileWatcher.hpp
+++ b/src/ASGE/Core/Filesystem/FileWatcher.hpp
@@ -65,8 +65,6 @@ std::ostream& operator<<( std::ostream& inOss, FEventType inMask ) noexcept;
 #ifdef _WIN32
 using native_event_t = DWORD;
 using handle_t = HANDLE;
-#elif defined(__APPLE__)
-using native_event_t = std::uint32_t;
 #else
 using native_event_t = std::uint32_t;
 using handle_t = std::int32_t;

--- a/src/ASGE/Core/Math/LinearAlgebra/Vector2.hpp
+++ b/src/ASGE/Core/Math/LinearAlgebra/Vector2.hpp
@@ -21,14 +21,21 @@ public:
     using typename base::reference;
     using typename base::const_reference;
 
-    using base::VecN; // Inherit all constructors
-
     static Vec2 Zero()
     {
         return Vec2( base::Zero() );
     }
 
-    /* Conversion constructor (Crucial for the operators below) */
+    Vec2() = default;
+
+    template<_internal::Numeric... Us>
+    requires (sizeof...(Us) == 2)
+    explicit Vec2( Us... inValues ) : base( inValues... )
+    {}
+
+    Vec2( std::initializer_list<T> inList ) : base( inList )
+    {}
+
     Vec2(const base& inBase) : base(inBase) {}
 
     reference x() { return (*this)[0]; }

--- a/tests/unit/Math/VectorNTests.cpp
+++ b/tests/unit/Math/VectorNTests.cpp
@@ -14,10 +14,22 @@ class TestVec3 final : public VecN<3, T, TestVec3<T>>
 {
 public:
     using base = VecN<3, T, TestVec3<T>>;
-    using base::VecN;
     using typename base::value_type;
 
-    TestVec3(base const& inBase) : base(inBase) {}
+    TestVec3() = default;
+
+    explicit TestVec3( value_type inValue ) : base( inValue )
+    {}
+
+    template<_internal::Numeric... Us>
+    requires (sizeof...(Us) == 3)
+    explicit TestVec3( Us... inValues ) : base( inValues... )
+    {}
+
+    TestVec3( std::initializer_list<T> inList ) : base( inList )
+    {}
+
+    explicit TestVec3(base const& inBase) : base(inBase) {}
 
     using base::operator+;
     using base::operator-;


### PR DESCRIPTION
The engine only built on Linux and Windows before. The FileWatcher #else branch was inotify/epoll, and there was no macOS preset or install script. This makes it build and pass its full test suite on macOS.
FileWatcher gets a new `__APPLE__` branch backed by `FSEvents` (CoreServices), macOS's equivalent of `inotify`. A couple of things needed care: FSEvents only delivers events after the stream is scheduled on a dispatch queue/run loop, the listener has to be connected before the stream starts or the initial batch is lost, FSEvents reports canonical paths (/private/var/... not /var/...) so matching is done on resolved paths, and its flags are cumulative so Modified has to be checked before Created.

#### 

Apple-clang also rejected a couple of things GCC/MSVC accept: the using base::VecN constructor-inheritance in Vec2 (same in the TestVec3 test) is suppressed by the conversion ctor, so I switched to explicit delegating ctors; and std::atomic<shared_ptr<...>> in ConfigurationManager isn't supported, but every access is already mutex-guarded so it just becomes a plain shared_ptr.

Also added: macos/macos-ci CMake presets, install-sdl-mac.sh (Homebrew sdl3), a platform-aware install-deps.sh, CoreServices linking on APPLE, and a macos-latest job in the CTest workflow.