### PR TITLE
ci(release): :green_heart: Add macOS artifacts to release-on-tag workflow

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -25,6 +25,10 @@ jobs:
             configure_preset: windows-package
             build_preset: windows-package
             archive: asge-${{ github.ref_name }}-windows-x64.zip
+          - os: macos-latest
+            configure_preset: macos-package
+            build_preset: macos-package
+            archive: asge-${{ github.ref_name }}-macos-arm64.tar.gz
 
     steps:
       - uses: actions/checkout@v4
@@ -35,8 +39,8 @@ jobs:
         with:
           cmake-version: "latest"
 
-      - name: Install dependencies on Linux
-        if: runner.os == 'Linux'
+      - name: Install dependencies on Linux or macOS
+        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: bash scripts/install-deps.sh
 
       - name: Install dependencies on Windows
@@ -53,8 +57,8 @@ jobs:
       - name: Install
         run: cmake --install build --config Release --prefix install
 
-      - name: Archive (Linux)
-        if: runner.os == 'Linux'
+      - name: Archive (Linux or macOS)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: tar -czf ${{ matrix.archive }} -C install .
 
       - name: Archive (Windows)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -125,6 +125,18 @@
                 "BUILD_TESTING": "ON",
                 "ASGE_BUILD_EXAMPLES": "OFF"
             }
+        },
+        {
+            "name": "macos-package",
+            "displayName": "macOS (package)",
+            "inherits": "macos-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "SDL3_DIR": "/opt/homebrew/lib/cmake/SDL3",
+                "BUILD_TESTING": "OFF",
+                "ASGE_BUILD_EXAMPLES": "OFF",
+                "ASGE_INSTALL": "ON"
+            }
         }
     ],
     "buildPresets": [
@@ -167,6 +179,10 @@
         {
             "name": "macos-ci",
             "configurePreset": "macos-ci"
+        },
+        {
+            "name": "macos-package",
+            "configurePreset": "macos-package"
         }
     ],
     "testPresets": [


### PR DESCRIPTION
## Summary
- Add a `macos-package` configure/build preset mirroring `linux-package`/`windows-package` (Release, tests+examples off, `ASGE_INSTALL=ON`).
- Add `macos-latest` to the `release-on-tag.yml` matrix so tagged releases now produce a macOS artifact (`asge-<tag>-macos-arm64.tar.gz`).
- Merge the Linux/macOS "Install dependencies" and "Archive" steps into single conditional steps to avoid duplication.

## Context
`ctest.yml` already builds/tests on `macos-latest` (#22), but `release-on-tag.yml` was never updated to package macOS artifacts on release tags — this closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)