### PR TITLE
fix: Fix subdirectory-consumer CMake build (CMAKE_SOURCE_DIR paths + SDL3 target visibility)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,52 @@ include(GNUInstallDirs)
 
 option(ASGE_INSTALL "Generate install rules for the ASGE library" ${PROJECT_IS_TOP_LEVEL})
 
-# Search for SDL library
+# Search for SDL library. Deliberately CMAKE_CURRENT_SOURCE_DIR (== this
+# file's own directory) rather than CMAKE_SOURCE_DIR (the outermost
+# listfile's directory): when ASGE is pulled in via add_subdirectory() from
+# another project, CMAKE_SOURCE_DIR points at that project's root, not this
+# repo, so the vendored SDL3 config would never be found.
 if(WIN32)
-    set(SDL3_DIR "${CMAKE_SOURCE_DIR}/third-party/SDL/cmake")
+    set(SDL3_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third-party/SDL/cmake")
 else()
-    set(SDL3_DIR "${CMAKE_SOURCE_DIR}/third-party/SDL/lib/cmake/SDL3")
+    set(SDL3_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third-party/SDL/lib/cmake/SDL3")
 endif()
 
 find_package(SDL3 REQUIRED CONFIG COMPONENTS SDL3)
+
+# find_package(CONFIG) imports the real SDL3::SDL3-shared/-static targets
+# (and the SDL3::SDL3 convenience name, an ALIAS of whichever one exists)
+# only into this directory's scope by default, so a consumer's own
+# top-level CMakeLists.txt -- the one directory add_subdirectory() can
+# never expose targets upward to -- would otherwise never see them (e.g.
+# to copy the runtime DLL next to its own executable, the same way
+# examples/CMakeLists.txt does). Promote the real targets to global
+# visibility so they resolve from any directory scope; ALIAS targets can't
+# take IMPORTED_GLOBAL directly (and, being aliases created before this
+# runs, wouldn't retroactively become global anyway), so consumers reach
+# SDL3 through the asge_copy_sdl3_runtime() helper below rather than
+# through SDL3::SDL3 itself.
+if(TARGET SDL3::SDL3-shared)
+    set_target_properties(SDL3::SDL3-shared PROPERTIES IMPORTED_GLOBAL TRUE)
+endif()
+if(TARGET SDL3::SDL3-static)
+    set_target_properties(SDL3::SDL3-static PROPERTIES IMPORTED_GLOBAL TRUE)
+endif()
+
+# Copies the SDL3 runtime DLL next to <target>'s output on Windows, the way
+# examples/CMakeLists.txt's setup_example() does for in-repo examples.
+# Consumers linking ASGE from another project should call this instead of
+# reaching for SDL3::SDL3 themselves -- see the IMPORTED_GLOBAL note above
+# for why that target isn't reliably visible outside this directory.
+function(asge_copy_sdl3_runtime target_name)
+    if(WIN32 AND TARGET SDL3::SDL3-shared)
+        add_custom_command(TARGET ${target_name} POST_BUILD
+            COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+                "$<TARGET_FILE:SDL3::SDL3-shared>"
+                "$<TARGET_FILE_DIR:${target_name}>"
+        )
+    endif()
+endfunction()
 
 # stb single-header libraries (image loading, font rasterization, ...),
 # vendored via scripts/install-stb.* into third-party/stb -- see that script
@@ -32,13 +70,13 @@ set(ASGE_STB_HEADERS
 add_library(stb INTERFACE)
 add_library(stb::stb ALIAS stb)
 target_include_directories(stb INTERFACE
-    "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/third-party/stb>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/stb>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
 if(ASGE_INSTALL)
     foreach(stb_header IN LISTS ASGE_STB_HEADERS)
         install(
-            FILES "${CMAKE_SOURCE_DIR}/third-party/stb/${stb_header}"
+            FILES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/stb/${stb_header}"
             DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
         )
     endforeach()

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Built examples land in `bin/`.
 ## Using ASGE in your own C++ project
 
 ASGE builds a static library target and installs a CMake package config, so
-it can be consumed either as a subdirectory or as an installed package.
+it can be consumed as a subdirectory, via `FetchContent`, or as an
+installed package.
 
 ### Option 1 — `add_subdirectory`
 
@@ -107,7 +108,42 @@ instead of reaching for the SDL3 target directly:
 asge_copy_sdl3_runtime(my_game)
 ```
 
-### Option 2 — installed package
+### Option 2 — `FetchContent`
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+    asge
+    GIT_REPOSITORY https://github.com/lmriccardo/a-simple-game-engine.git
+    GIT_TAG main
+    SOURCE_DIR "${CMAKE_SOURCE_DIR}/third-party/asge"
+)
+FetchContent_MakeAvailable(asge)
+
+add_executable(my_game main.cpp)
+target_link_libraries(my_game PRIVATE ASGE)
+asge_copy_sdl3_runtime(my_game)
+```
+
+ASGE's own dependencies (SDL3, stb) aren't fetched by CMake — they're
+vendored via `scripts/install-deps.ps1`/`.sh`, run separately from the
+build (see [Building from source](#building-from-source) above). That means
+the **first** `FetchContent_MakeAvailable` call above will fail: it clones
+ASGE into `third-party/asge`, then immediately tries to configure it, and
+`find_package(SDL3)` won't find anything yet. Run ASGE's install script
+against the freshly-cloned copy once —
+
+```powershell
+./third-party/asge/scripts/install-deps.ps1     # Windows
+```
+```bash
+./third-party/asge/scripts/install-deps.sh      # Linux / macOS
+```
+
+— then reconfigure; `FetchContent` sees `third-party/asge` already
+populated and it builds normally from there on.
+
+### Option 3 — installed package
 
 Install ASGE (`cmake --install build`), then from your own project:
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ add_executable(my_game main.cpp)
 target_link_libraries(my_game PRIVATE ASGE)
 ```
 
+On Windows, `my_game.exe` also needs `SDL3.dll` next to it at runtime. Since
+`add_subdirectory` never exposes ASGE's own SDL3 target back up to your
+project's directory scope, use the helper ASGE defines for exactly this
+instead of reaching for the SDL3 target directly:
+
+```cmake
+asge_copy_sdl3_runtime(my_game)
+```
+
 ### Option 2 — installed package
 
 Install ASGE (`cmake --install build`), then from your own project:
@@ -154,7 +163,12 @@ int main()
 
 More examples covering shapes, textures, text, ECS, input handling and
 configuration loading live under [examples/](examples/) and are built
-alongside the engine when `ASGE_BUILD_EXAMPLES` is `ON`.
+alongside the engine when `ASGE_BUILD_EXAMPLES` is `ON`. In particular, for
+drawing a texture and reading keyboard/mouse input — the two things a
+real game needs beyond the empty overrides above — see
+[examples/texture_demo](examples/texture_demo) (`IRenderer::DrawTexture`)
+and [examples/moving_box](examples/moving_box)
+(`InputState::IsKeyDown`/`IsKeyPressed`).
 
 ## Testing
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,13 +9,7 @@ macro(setup_example target_name)
             $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->
     )
 
-    if(WIN32)
-        add_custom_command(TARGET ${target_name} POST_BUILD
-            COMMAND "${CMAKE_COMMAND}" -E copy_if_different
-                $<TARGET_FILE:SDL3::SDL3>
-                $<TARGET_FILE_DIR:${target_name}>
-        )
-    endif()
+    asge_copy_sdl3_runtime(${target_name})
 endmacro()
 
 add_subdirectory(background_changer)


### PR DESCRIPTION
Fixes #26

## Problem
Following the README's "Subdirectory Approach" (`add_subdirectory(third-party/asge)` from a consuming project) failed to configure, for two reasons:

1. `SDL3_DIR` and the stb include/install paths were built from `CMAKE_SOURCE_DIR`, which is always the *outermost* project's directory — not this repo's own directory when it's pulled in via `add_subdirectory`. A consumer would get `find_package(SDL3)` failures looking in their own tree instead of ASGE's vendored `third-party/SDL`.
2. `SDL3::SDL3` (used by `examples/CMakeLists.txt` to copy `SDL3.dll` next to each example) is only visible in the directory `find_package(SDL3)` ran in and its subdirectories — never in a consumer's own top-level `CMakeLists.txt`, which `add_subdirectory()` can never expose targets upward to. It's also an `ALIAS` target, so it can't be promoted to `IMPORTED_GLOBAL` directly (CMake rejects `set_target_properties` on an alias), and promoting the real target it points to *after* the alias already exists doesn't retroactively make that alias global either.

## Fix
- Switched `SDL3_DIR` and the stb paths to `CMAKE_CURRENT_SOURCE_DIR`, so they always resolve against ASGE's own tree regardless of how/where it's consumed.
- Promoted the real `SDL3::SDL3-shared`/`SDL3::SDL3-static` imported targets to `IMPORTED_GLOBAL`, and added an `asge_copy_sdl3_runtime(<target>)` helper function consumers call to copy the runtime DLL, so they never need direct access to any SDL3 target name (including the `ALIAS`, which stays non-global). `examples/CMakeLists.txt`'s `setup_example()` now goes through the same helper instead of duplicating the copy step.
- README: added a note on calling `asge_copy_sdl3_runtime()` from the subdirectory-integration example, and a pointer from the basic usage example to `texture_demo`/`moving_box` for the texture-drawing and input APIs (the "Minor" doc gap mentioned in the issue).

## Verification
Reproduced the issue exactly (scratch consumer project doing `add_subdirectory` of this repo from a sibling directory) — confirmed both original errors on `main`, and a clean configure + build + `SDL3.dll` landing next to the consumer's executable after this change. Also reconfigured and rebuilt an in-repo example (`moving_box`) to confirm nothing regressed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)