### PR TITLE
fix(concurrent): Stop Thread subclasses from destroying via base dtor

### DIFF
--- a/src/ASGE/Core/Concurrent/Thread.cpp
+++ b/src/ASGE/Core/Concurrent/Thread.cpp
@@ -1,9 +1,19 @@
 #include "Thread.hpp"
+#include <ASGE/Core/Errors.hpp>
 
 using namespace asge::concurrent;
 
 asge::concurrent::Thread::~Thread()
 {
+    // A subclass reaching here still Joinable() means its own destructor
+    // didn't Cancel()+Join() as required (see Thread's class doc comment)
+    // -- the Cancel()+Join() below is only a best-effort fallback, since
+    // by now the vtable has already reverted away from the derived Run()
+    // override and the background thread can crash into it mid-dispatch.
+    ASGE_ASSERT(!Joinable(),
+        "Thread subclass destroyed without Cancel()+Join() in its own "
+        "destructor -- see the @warning on Thread's class doc comment");
+
     Cancel();
     Join();
 }

--- a/src/ASGE/Core/Concurrent/Thread.hpp
+++ b/src/ASGE/Core/Concurrent/Thread.hpp
@@ -33,6 +33,15 @@ namespace asge::concurrent
  * Each instance is assigned a unique name (defaulting to ASGE_Thread_N)
  * used for identification and debugging. Copy is disabled since a thread
  * represents a unique resource. Move is supported.
+ *
+ * @warning Every subclass MUST call Cancel() then Join() in its own
+ * destructor before returning. ~Thread() also does this, but only as a
+ * best-effort safety net — by the time a base-class destructor runs, the
+ * vtable has already reverted away from the derived override, so if the
+ * background thread is still mid-loop it can dispatch into Run()'s pure
+ * virtual slot in Thread and crash ("pure virtual function called").
+ * Joining from the most-derived destructor is the only place guaranteed
+ * to run before that vtable switch happens.
  */
 class Thread
 {
@@ -159,6 +168,10 @@ public:
     : Thread(inCtx), m_Func( std::forward<_Callable>(inFunc) ),
       m_Args( std::forward<_Args>(inArgs)... )
     {}
+
+    // Must Cancel()+Join() here, not rely on ~Thread() -- see the
+    // @warning on Thread's class doc comment.
+    ~ThreadImpl() override { Cancel(); Join(); }
 };
 
 }

--- a/src/ASGE/Core/Concurrent/ThreadPool.hpp
+++ b/src/ASGE/Core/Concurrent/ThreadPool.hpp
@@ -131,7 +131,12 @@ public:
     Worker(Worker const&) = delete;
     Worker& operator=(Worker const&) = delete;
 
-    ~Worker() override = default;
+    // Must Cancel()+Join() here, not rely on ~Thread() -- see the
+    // @warning on Thread's class doc comment. ThreadPool::~ThreadPool()
+    // already joins every worker before this runs, so this is a no-op
+    // in that path; it only matters if a Worker is ever destroyed on
+    // its own (e.g. ThreadPool's constructor throwing partway through).
+    ~Worker() override { Cancel(); Join(); }
 };
 
 template<typename _Callable>

--- a/tests/unit/Concurrent/ThreadTests.cpp
+++ b/tests/unit/Concurrent/ThreadTests.cpp
@@ -22,6 +22,10 @@ public:
     CountingThread(std::string const& inName, int inLimit, bool inDaemon = false)
         : Thread(inName, nullptr, inDaemon), limit(inLimit) {}
 
+    // Must Cancel()+Join() here, not rely on ~Thread() -- see the
+    // @warning on Thread's class doc comment.
+    ~CountingThread() override { Cancel(); Join(); }
+
 protected:
     void Run(context_pointer& ctx) override
     {
@@ -37,6 +41,10 @@ class IdleThread final : public Thread
 public:
     IdleThread() : Thread() {}
     explicit IdleThread(std::string const& inName) : Thread(inName) {}
+
+    // Must Cancel()+Join() here, not rely on ~Thread() -- see the
+    // @warning on Thread's class doc comment.
+    ~IdleThread() override { Cancel(); Join(); }
 
 protected:
     void Run(context_pointer&) override
@@ -173,6 +181,32 @@ TEST(Thread, DestructorCancelsAndJoins)
     SUCCEED();
 }
 
+// Regression test for issue #40: Thread::~Thread() alone can't safely stop
+// a background thread that dispatches virtual Run() calls on `this` --
+// by the time a base-class destructor runs, the vtable has already
+// reverted away from the derived override, so a worker thread still
+// mid-loop could dispatch straight into Run()'s pure-virtual slot in
+// Thread and crash ("pure virtual function called", reliably hit on
+// macOS CI). The fix moves Cancel()+Join() into each subclass's own
+// destructor instead. Repeating construct-start-destroy many times, with
+// no explicit Cancel()/Join() by the caller, maximises the chance of
+// landing in the race window that used to crash.
+TEST(Thread, RepeatedStartAndImmediateDestructionDoesNotCrash)
+{
+    constexpr int kIterations = 300;
+    for (int ii = 0; ii < kIterations; ++ii)
+    {
+        IdleThread t;
+        t.Start();
+    }
+    for (int ii = 0; ii < kIterations; ++ii)
+    {
+        CountingThread t(1);
+        t.Start();
+    }
+    SUCCEED();
+}
+
 TEST(Thread, DetachMakesDaemon)
 {
     IdleThread t;
@@ -281,6 +315,22 @@ TEST(Thread, ThreadStaticStart_ParentContextCancellationStopsThread)
     parent->Cancel();
     t->Join();
     EXPECT_GT(count.load(), 0);
+}
+
+// Same regression as Thread.RepeatedStartAndImmediateDestructionDoesNotCrash
+// (see issue #40), exercised through ThreadImpl -- the concrete class
+// backing this static factory -- rather than a hand-written subclass. The
+// returned thread_pointer is destroyed with no explicit Cancel()/Join() by
+// the caller, relying on ThreadImpl's own destructor to do it safely.
+TEST(Thread, ThreadStaticStart_RepeatedStartAndImmediateDestructionDoesNotCrash)
+{
+    constexpr int kIterations = 300;
+    auto callback = [](context_pointer&) { std::this_thread::yield(); };
+    for (int ii = 0; ii < kIterations; ++ii)
+    {
+        [[maybe_unused]] auto t = Thread::Start(false, nullptr, callback);
+    }
+    SUCCEED();
 }
 
 }


### PR DESCRIPTION
## Summary

Fixes #40.

`Thread::~Thread()` tried to `Cancel()`+`Join()` the background thread itself, but by the time a base-class destructor's body runs, the object's vtable has already reverted away from the derived `Run()` override. If the background thread was still mid-loop in `_Run()` at that instant, its next virtual call landed on `Run()`'s pure-virtual slot in `Thread` and crashed (`"pure virtual function called"`) — reliably observed on macOS CI (libc++abi enforces this consistently). This is a genuine data race in the C++ object model — [Herb Sutter's GotW #91](https://herbsutter.com/gotw/_91/) case study, essentially: a base destructor can never safely join a thread that calls virtuals on itself, because the vtable switch happens before its own body even runs. The only destructor guaranteed to run before that switch is the most-derived subclass's own.

I don't have macOS hardware, so I couldn't reproduce the crash directly. Instead I:
- Verified the fix against the well-known GotW #91 pattern (this is not a novel diagnosis — it's a documented, understood C++ pitfall).
- Tried to force a local repro on Windows by reverting the fix and widening the destructor race window with an artificial sleep in `_Run()`'s loop — it didn't crash even after 300 stress iterations, which is consistent with this being UB that MSVC's Debug build happens not to surface (rather than something macOS-specific): the standard leaves it undefined, and different toolchains expose it differently.
- Am relying on this repo's existing `macos-latest` CI job (already in `.github/workflows/ctest.yml`) to give the authoritative answer once this PR runs.

## Changes

- `src/ASGE/Core/Concurrent/Thread.hpp` — documents the new requirement on `Thread`'s class doc comment (every subclass MUST `Cancel()`+`Join()` in its own destructor); `ThreadImpl` (backing the static `Thread::Start()` factory) now does so.
- `src/ASGE/Core/Concurrent/Thread.cpp` — `~Thread()` keeps its `Cancel()`+`Join()` as a best-effort fallback, now guarded by an `ASGE_ASSERT(!Joinable(), ...)` so silent misuse doesn't go unnoticed in Debug builds.
- `src/ASGE/Core/Concurrent/ThreadPool.hpp` — `Worker` (the pool's per-thread unit) now does the same. `ThreadPool::~ThreadPool()` already joined every worker explicitly before this runs, so it's a no-op there in practice; it only matters if a `Worker` is ever destroyed on its own (e.g. `ThreadPool`'s constructor throwing partway through construction).
- `tests/unit/Concurrent/ThreadTests.cpp` — the `IdleThread`/`CountingThread` test doubles now follow the same contract, plus two new regression/stress tests (`Thread.RepeatedStartAndImmediateDestructionDoesNotCrash`, `Thread.ThreadStaticStart_RepeatedStartAndImmediateDestructionDoesNotCrash`) that construct-start-destroy 300 threads each with no explicit `Cancel()`/`Join()` by the caller, to guard against this regressing.

## Testing

- `ctest --preset windows-debug` — full suite, 603/603 passing.
- `ASGE_ConcurrentTests` run standalone — 113/113 passing.
- Confirmed the new regression tests pass against the actual fix; also temporarily reverted the fix + widened the race window locally to sanity-check the repro attempt (see Summary) before restoring the real fix.
- Watching this PR's `macos-latest` CI job as the real confirmation, since that's the platform the crash was originally observed on.