### PR TITLE
fix(concurrent): Stop Thread::Detach() racing a fast-cancelling callable

### DIFF
--- a/src/ASGE/Core/Concurrent/Thread.cpp
+++ b/src/ASGE/Core/Concurrent/Thread.cpp
@@ -54,7 +54,12 @@ void asge::concurrent::Thread::Join()
 
 void asge::concurrent::Thread::Detach()
 {
-    if ( !m_Ctx->Done() && m_Thread != nullptr )
+    // std::thread::detach() only requires joinable() -- whether the
+    // underlying function has already returned doesn't matter. Gating
+    // this on m_Ctx->Done() instead raced against fast-cancelling
+    // callables: the background thread could cancel its own context
+    // before the caller got here, silently skipping the detach.
+    if ( m_Thread != nullptr && m_Thread->joinable() && !m_Daemon )
     {
         m_Thread->detach();
         m_Daemon = true;

--- a/src/ASGE/Core/Concurrent/Thread.hpp
+++ b/src/ASGE/Core/Concurrent/Thread.hpp
@@ -130,7 +130,17 @@ public:
     static thread_pointer Start(bool, context_pointer, _Callable&&, _Args&& ...);
 
     void Join();
+
+    /**
+     * @brief Detaches the running thread, marking it a daemon.
+     *
+     * A no-op if the thread was never started, is already detached, or has
+     * already been joined. Safe to call regardless of whether the running
+     * thread's work has finished -- detach() only requires the underlying
+     * std::thread to still be joinable, not still executing.
+     */
     void Detach();
+
     void Start();
     void Cancel();
 };

--- a/tests/unit/Concurrent/ThreadTests.cpp
+++ b/tests/unit/Concurrent/ThreadTests.cpp
@@ -219,6 +219,40 @@ TEST(Thread, DetachMakesDaemon)
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 }
 
+// Regression test for issue #42: Detach() used to gate the actual
+// std::thread::detach() call on `!m_Ctx->Done()`, so a thread whose
+// context was already cancelled by the time the caller called Detach()
+// was silently left un-detached (Daemon() stayed false, Joinable() stayed
+// true) -- exactly what CI caught on Thread.ThreadStaticStart_
+// DaemonThreadIsDetached when its fast-cancelling callback beat the
+// caller to Detach(). Cancelling first, deterministically, reproduces the
+// "loser" side of that race without depending on scheduling timing.
+TEST(Thread, Detach_AfterContextAlreadyCancelledStillDetaches)
+{
+    IdleThread t;
+    t.Start();
+    t.Cancel(); // context is Done() before Detach() is ever called
+    t.Detach();
+
+    EXPECT_TRUE(t.Daemon());
+    EXPECT_FALSE(t.Joinable());
+    // allow the (now detached) thread to observe the cancellation and
+    // exit before t is destroyed -- same convention as DetachMakesDaemon.
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+}
+
+TEST(Thread, Detach_CalledTwiceIsSafe)
+{
+    IdleThread t;
+    t.Start();
+    t.Cancel(); // give the background thread maximal time to observe this
+                // before it's detached, same reasoning as the test above
+    t.Detach();
+    EXPECT_NO_THROW(t.Detach()); // must not double-detach() an already-detached std::thread
+    EXPECT_TRUE(t.Daemon());
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+}
+
 // ─── Thread::Start (static factory) ──────────────────────────────────────────
 
 TEST(Thread, ThreadStaticStart_ReturnsNonNullPointer)


### PR DESCRIPTION
## Summary

Fixes #42.

`Detach()` gated the actual `std::thread::detach()` call on `!m_Ctx->Done()`, which raced against any callable that cancels its own context almost immediately: if the background thread ran and cancelled before the caller reached `Detach()`'s check, the call silently no-opped — `Daemon()` stayed `false` and `Joinable()` stayed `true` even though the caller explicitly asked for a daemon thread via `Start(true, ...)`. CI caught this on `Thread.ThreadStaticStart_DaemonThreadIsDetached` (see [run 32899584497](https://github.com/lmriccardo/a-simple-game-engine/actions/runs/32899584497/job/97970011262), the `macos-latest` job right after #41 landed) — that test's callback does nothing but cancel, so on a fast enough runner it consistently loses the race.

The `Done()` check never protected anything real: `std::thread::detach()` only requires `joinable()` to be true, regardless of whether the underlying function has already returned. `Detach()` now guards on `m_Thread->joinable() && !m_Daemon` instead — which also prevents a double `detach()` (UB) if `Detach()` is ever called twice.

## Changes

- `src/ASGE/Core/Concurrent/Thread.cpp` — `Detach()`'s guard fixed as above.
- `src/ASGE/Core/Concurrent/Thread.hpp` — added the missing Doxygen comment on `Detach()`'s declaration.
- `tests/unit/Concurrent/ThreadTests.cpp` — two new regression tests: `Thread.Detach_AfterContextAlreadyCancelledStillDetaches` deterministically reproduces the exact race (cancels *before* calling `Detach()`, so it no longer depends on scheduling luck), and `Thread.Detach_CalledTwiceIsSafe` covers the double-detach guard.

## Testing

- `ctest --preset windows-debug` — full suite, 605/605 passing (ran twice to be sure; a *different*, pre-existing `ConfigIntegrationTest` flaked once under full-suite load and passed reliably both standalone and on a full-suite retry — unrelated to this change, not touched here).
- `ASGE_ConcurrentTests` run standalone 8 times in a row, 115/115 each time, plus `ctest -R "^Thread\."` 3 times — no flakiness observed after moving the new tests' `Cancel()` before `Detach()` (an earlier draft of `Detach_CalledTwiceIsSafe` called `Cancel()` last and segfaulted once under full-suite load: a detached thread's stack-local owner got destroyed before the thread had a chance to observe cancellation and exit, the same "detach and hope" hazard `DetachMakesDaemon` already carries. Cancelling first gives the background thread the whole rest of the test body to exit before `t` goes out of scope, matching that existing convention).