### PR TITLE
feat(graphics): Add Image::AlphaContentBounds for trimming padded sprite regions

### DIFF
--- a/src/ASGE/Core/Graphics/Image.cpp
+++ b/src/ASGE/Core/Graphics/Image.cpp
@@ -1,7 +1,38 @@
 #include "Image.hpp"
 
+#include <algorithm>
+
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
+
+namespace
+{
+
+/** @brief Clamps inRegion so it lies fully within an image of inDimensions pixels. */
+asge::math::Rect ClampRegionToImage( asge::math::Rect const& inRegion, asge::math::Int2 inDimensions ) noexcept
+{
+    float const imgW = static_cast<float>( inDimensions.x() );
+    float const imgH = static_cast<float>( inDimensions.y() );
+
+    float const x0 = std::clamp( inRegion.x, 0.0f, imgW );
+    float const y0 = std::clamp( inRegion.y, 0.0f, imgH );
+    float const x1 = std::clamp( inRegion.x + inRegion.w, 0.0f, imgW );
+    float const y1 = std::clamp( inRegion.y + inRegion.h, 0.0f, imgH );
+
+    return { x0, y0, std::max( 0.0f, x1 - x0 ), std::max( 0.0f, y1 - y0 ) };
+}
+
+/** @brief True if the pixel at (inX, inY) in inImage is fully transparent (alpha == 0). */
+bool IsPixelTransparent( asge::graphics::Image const& inImage, std::size_t inX, std::size_t inY ) noexcept
+{
+    // Alpha is always the last byte of a pixel here: offset 3 of 4 for RGBA8,
+    // offset 0 of 1 for A8 (the pixel *is* its alpha).
+    std::size_t const bpp = asge::graphics::PixelFormatInfoFor( inImage.Format() ).s_BytesPerPixel;
+    std::uint8_t const* row = inImage.Data() + inY * inImage.Stride();
+    return row[inX * bpp + (bpp - 1)] == 0;
+}
+
+}
 
 asge::graphics::Image::Image(
     std::size_t inW, std::size_t inH, PixelFormat inFormat, data_t const &inData
@@ -26,6 +57,46 @@ std::uint8_t const *asge::graphics::Image::Data() const noexcept
 std::size_t asge::graphics::Image::Stride() const noexcept
 {
     return m_Width * PixelFormatInfoFor(m_Format).s_BytesPerPixel;
+}
+
+asge::math::Rect asge::graphics::Image::AlphaContentBounds() const noexcept
+{
+    return AlphaContentBounds( math::Rect{ 0.0f, 0.0f, static_cast<float>(m_Width), static_cast<float>(m_Height) } );
+}
+
+asge::math::Rect asge::graphics::Image::AlphaContentBounds( math::Rect const &inRegion ) const noexcept
+{
+    math::Rect const region = ClampRegionToImage( inRegion, Dimensions() );
+    if ( region.w <= 0.0f || region.h <= 0.0f ) return region;
+
+    auto const x0 = static_cast<std::size_t>(region.x);
+    auto const y0 = static_cast<std::size_t>(region.y);
+    auto const x1 = static_cast<std::size_t>(region.x + region.w); // exclusive
+    auto const y1 = static_cast<std::size_t>(region.y + region.h); // exclusive
+
+    std::size_t minX = x1, minY = y1, maxX = x0, maxY = y0;
+    bool foundContent = false;
+
+    for ( std::size_t y = y0; y < y1; ++y )
+    {
+        for ( std::size_t x = x0; x < x1; ++x )
+        {
+            if ( IsPixelTransparent( *this, x, y ) ) continue;
+
+            foundContent = true;
+            minX = std::min( minX, x );
+            minY = std::min( minY, y );
+            maxX = std::max( maxX, x + 1 ); // exclusive
+            maxY = std::max( maxY, y + 1 ); // exclusive
+        }
+    }
+
+    if ( !foundContent ) return region; // entirely transparent -- fall back to the region itself
+
+    return {
+        static_cast<float>(minX), static_cast<float>(minY),
+        static_cast<float>(maxX - minX), static_cast<float>(maxY - minY)
+    };
 }
 
 asge::Result<asge::graphics::Image> asge::graphics::Image::Image::Load(filesystem::Path const &inImagePath)

--- a/src/ASGE/Core/Graphics/Image.hpp
+++ b/src/ASGE/Core/Graphics/Image.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <span>
 #include <ASGE/Core/Math/LinearAlgebra/Vector2.hpp>
+#include <ASGE/Core/Math/Geometry/Rect.hpp>
 #include <ASGE/Core/Errors.hpp>
 #include <ASGE/Core/Filesystem/FileIO.hpp>
 #include "PixelFormat.hpp"
@@ -36,6 +37,21 @@ public:
     [[nodiscard]] PixelFormat Format() const noexcept;
     [[nodiscard]] std::uint8_t const* Data() const noexcept;
     [[nodiscard]] std::size_t Stride() const noexcept;
+
+    /**
+     * @brief Tight bounding box of this image's non-transparent pixels, in
+     *        its own pixel coordinates. Scans the whole image; see the
+     *        region overload below to scan just part of it.
+     */
+    [[nodiscard]] math::Rect AlphaContentBounds() const noexcept;
+
+    /**
+     * @brief Tight bounding box of the non-transparent pixels within
+     *        inRegion (clamped to this image's own bounds), in the image's
+     *        own pixel coordinates. Falls back to the clamped region itself
+     *        if every pixel in it is fully transparent.
+     */
+    [[nodiscard]] math::Rect AlphaContentBounds( math::Rect const& inRegion ) const noexcept;
 
     /**
      * @brief Reads an image file from disk and decodes it into an RGBA8 Image

--- a/tests/unit/Graphics/ImageTests.cpp
+++ b/tests/unit/Graphics/ImageTests.cpp
@@ -183,4 +183,122 @@ TEST_F(ReadImageTest, ValidBmpFileDecodesSuccessfully)
     ExpectDecodedSolidRedImage(result.Value());
 }
 
+// ─── AlphaContentBounds ─────────────────────────────────────────────────────
+
+// Builds an RGBA8 image where the pixel at (x, y) is opaque iff inGetAlpha(x, y)
+// is true, fully transparent otherwise. RGB is arbitrary, non-zero, so a test
+// accidentally checking color bytes instead of alpha would still fail loudly.
+template<typename AlphaFn>
+Image MakeRgba8Image(std::size_t inWidth, std::size_t inHeight, AlphaFn inGetAlpha)
+{
+    Image::data_t data(inWidth * inHeight * 4, std::uint8_t{0});
+    for (std::size_t y = 0; y < inHeight; ++y)
+    {
+        for (std::size_t x = 0; x < inWidth; ++x)
+        {
+            std::size_t const idx = (y * inWidth + x) * 4;
+            data[idx + 0] = 200;
+            data[idx + 1] = 100;
+            data[idx + 2] = 50;
+            data[idx + 3] = inGetAlpha(x, y) ? std::uint8_t{255} : std::uint8_t{0};
+        }
+    }
+    return Image(inWidth, inHeight, PixelFormat::RGBA8, data);
+}
+
+// Same as MakeRgba8Image, but for A8 -- the pixel byte itself is the alpha.
+template<typename AlphaFn>
+Image MakeA8Image(std::size_t inWidth, std::size_t inHeight, AlphaFn inGetAlpha)
+{
+    Image::data_t data(inWidth * inHeight, std::uint8_t{0});
+    for (std::size_t y = 0; y < inHeight; ++y)
+        for (std::size_t x = 0; x < inWidth; ++x)
+            data[y * inWidth + x] = inGetAlpha(x, y) ? std::uint8_t{255} : std::uint8_t{0};
+    return Image(inWidth, inHeight, PixelFormat::A8, data);
+}
+
+TEST(AlphaContentBoundsTest, FullyOpaqueImage_ReturnsWholeImage)
+{
+    Image image = MakeRgba8Image(4, 3, [](std::size_t, std::size_t) { return true; });
+
+    auto const bounds = image.AlphaContentBounds();
+
+    EXPECT_FLOAT_EQ(bounds.x, 0.0f);
+    EXPECT_FLOAT_EQ(bounds.y, 0.0f);
+    EXPECT_FLOAT_EQ(bounds.w, 4.0f);
+    EXPECT_FLOAT_EQ(bounds.h, 3.0f);
+}
+
+TEST(AlphaContentBoundsTest, PaddedSprite_ReturnsTightBoundsSmallerThanCanvas)
+{
+    // 6x6 canvas, only the 2x2 block at (2,2)-(3,3) is opaque -- the rest is
+    // the kind of mixed padding issue #46 was filed about.
+    Image image = MakeRgba8Image(6, 6, [](std::size_t x, std::size_t y) {
+        return x >= 2 && x <= 3 && y >= 2 && y <= 3;
+    });
+
+    auto const bounds = image.AlphaContentBounds();
+
+    EXPECT_FLOAT_EQ(bounds.x, 2.0f);
+    EXPECT_FLOAT_EQ(bounds.y, 2.0f);
+    EXPECT_FLOAT_EQ(bounds.w, 2.0f);
+    EXPECT_FLOAT_EQ(bounds.h, 2.0f);
+}
+
+TEST(AlphaContentBoundsTest, RegionOverload_OnlyConsidersPixelsInsideRegion)
+{
+    // Opaque pixel at (0,0) sits outside the scanned region and must be
+    // ignored; only (5,5), inside the region, should shape the result.
+    Image image = MakeRgba8Image(10, 10, [](std::size_t x, std::size_t y) {
+        return (x == 0 && y == 0) || (x == 5 && y == 5);
+    });
+
+    auto const bounds = image.AlphaContentBounds(asge::math::Rect{ 4.0f, 4.0f, 4.0f, 4.0f });
+
+    EXPECT_FLOAT_EQ(bounds.x, 5.0f);
+    EXPECT_FLOAT_EQ(bounds.y, 5.0f);
+    EXPECT_FLOAT_EQ(bounds.w, 1.0f);
+    EXPECT_FLOAT_EQ(bounds.h, 1.0f);
+}
+
+TEST(AlphaContentBoundsTest, RegionExtendingPastImageBounds_IsClamped)
+{
+    Image image = MakeRgba8Image(4, 4, [](std::size_t, std::size_t) { return true; });
+
+    auto const bounds = image.AlphaContentBounds(asge::math::Rect{ 2.0f, 2.0f, 100.0f, 100.0f });
+
+    EXPECT_FLOAT_EQ(bounds.x, 2.0f);
+    EXPECT_FLOAT_EQ(bounds.y, 2.0f);
+    EXPECT_FLOAT_EQ(bounds.w, 2.0f); // clamped: image width(4) - region x(2)
+    EXPECT_FLOAT_EQ(bounds.h, 2.0f);
+}
+
+TEST(AlphaContentBoundsTest, EntirelyTransparentRegion_FallsBackToClampedRegion)
+{
+    Image image = MakeRgba8Image(10, 10, [](std::size_t, std::size_t) { return false; });
+
+    auto const bounds = image.AlphaContentBounds(asge::math::Rect{ 2.0f, 3.0f, 5.0f, 100.0f });
+
+    // Falls back to the region itself, but still clamped -- h shrinks from
+    // 100 to what actually fits (image height 10 - region y 3 = 7).
+    EXPECT_FLOAT_EQ(bounds.x, 2.0f);
+    EXPECT_FLOAT_EQ(bounds.y, 3.0f);
+    EXPECT_FLOAT_EQ(bounds.w, 5.0f);
+    EXPECT_FLOAT_EQ(bounds.h, 7.0f);
+}
+
+TEST(AlphaContentBoundsTest, A8Format_TreatsThePixelByteItselfAsAlpha)
+{
+    Image image = MakeA8Image(5, 5, [](std::size_t x, std::size_t y) {
+        return x == 1 && y == 1;
+    });
+
+    auto const bounds = image.AlphaContentBounds();
+
+    EXPECT_FLOAT_EQ(bounds.x, 1.0f);
+    EXPECT_FLOAT_EQ(bounds.y, 1.0f);
+    EXPECT_FLOAT_EQ(bounds.w, 1.0f);
+    EXPECT_FLOAT_EQ(bounds.h, 1.0f);
+}
+
 }


### PR DESCRIPTION
## Summary

Fixes #46. `Image` had no way to find the tight bounding box of a region's non-transparent pixels, so consumers with mixed-padding sprite sheets (e.g. a walk-cycle row that leaves clearance for swinging limbs next to an idle row cropped tight) had to hand-roll a manual `Data()`/`Stride()` alpha scan just to size/crop by actual content instead of nominal cell size.

## Changes

- **`src/ASGE/Core/Graphics/Image.hpp`** — added two `AlphaContentBounds()` overloads: one scanning the whole image, one scanning a caller-given `math::Rect` region. Doc comments describe the clamp-then-fallback-to-region behavior for the region overload.
- **`src/ASGE/Core/Graphics/Image.cpp`** — implementation, plus two `.cpp`-local helpers: `ClampRegionToImage` (clamps a region to the image's own bounds so an out-of-range region never reads past the pixel buffer) and `IsPixelTransparent` (alpha is always the last byte of a pixel, so this works for both `RGBA8` and `A8` without branching on format). If the clamped region is entirely transparent, the function falls back to returning that clamped region itself, as requested in the issue.
- **`tests/unit/Graphics/ImageTests.cpp`** — added an `AlphaContentBoundsTest` suite (6 cases) covering: a fully opaque image, a padded sprite (tight bounds smaller than the canvas), a region-scoped scan that ignores content outside the region, a region clamped when it extends past the image bounds, an entirely-transparent region falling back to the clamped region, and the `A8` pixel format.

## Testing

- `cmake --build --preset windows-debug --target ASGE_GraphicsTests` — builds clean
- `ASGE_GraphicsTests.exe --gtest_filter=AlphaContentBoundsTest.*` — 6/6 passed
- `cmake --build --preset windows-debug` (full project) — builds clean
- `ctest --preset windows-debug` — 701/701 passed (695 baseline + 6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
