### PR TITLE
feat(rendering): Add DrawTextureAnchored for stable pivots on variably-cropped frames

### DIFF
--- a/src/ASGE/Video/Graphics/Renderer.hpp
+++ b/src/ASGE/Video/Graphics/Renderer.hpp
@@ -148,4 +148,25 @@ public:
     [[nodiscard]] virtual bool IsValid() const = 0;
 };
 
+/**
+ * @brief Draws inSrcRect anchored at a normalized point within it, so that
+ *        point (not inDestRect's top-left corner) lands at inDestRect's
+ *        (x, y) — {0,0} reproduces plain DrawTexture(srcRect, destRect).
+ *        Lets one fixed anchor stay put on screen while inSrcRect's size
+ *        varies call to call (e.g. differently-cropped animation frames).
+ */
+inline void DrawTextureAnchored(
+    IRenderer const& inRenderer, ITexture const& inTexture,
+    math::Rect const& inSrcRect, math::Rect const& inDestRect,
+    math::Float2 const& inSrcAnchor = math::Float2{ 0.0f, 0.0f }
+) noexcept
+{
+    math::Rect const adjustedDest{
+        inDestRect.x - inSrcAnchor.x() * inDestRect.w,
+        inDestRect.y - inSrcAnchor.y() * inDestRect.h,
+        inDestRect.w, inDestRect.h
+    };
+    inRenderer.DrawTexture( inTexture, inSrcRect, adjustedDest );
+}
+
 } // namespace asge::video

--- a/tests/unit/Video/GraphicsInterfaceTests.cpp
+++ b/tests/unit/Video/GraphicsInterfaceTests.cpp
@@ -15,6 +15,7 @@
 namespace
 {
 
+using asge::video::DrawTextureAnchored;
 using asge::video::IRenderer;
 using asge::video::ITexture;
 using asge::video::IWindow;
@@ -71,6 +72,8 @@ public:
     mutable int s_DrawTextureRectCalls{0};
     mutable int s_DrawTexturePositionCalls{0};
     mutable int s_DrawTextureSrcDestCalls{0};
+    mutable asge::math::Rect s_LastSrcRect{};
+    mutable asge::math::Rect s_LastDestRect{};
     mutable int s_DrawTexture9GridCalls{0};
     mutable int s_DrawTextureTiledCalls{0};
     mutable int s_DrawTextureAffineCalls{0};
@@ -113,9 +116,11 @@ public:
         ++s_DrawTexturePositionCalls;
     }
 
-    void DrawTexture(ITexture const&, asge::math::Rect const&, asge::math::Rect const&) const noexcept override
+    void DrawTexture(ITexture const&, asge::math::Rect const& inSrcRect, asge::math::Rect const& inDestRect) const noexcept override
     {
         ++s_DrawTextureSrcDestCalls;
+        s_LastSrcRect = inSrcRect;
+        s_LastDestRect = inDestRect;
     }
 
     void DrawTexture9Grid(
@@ -220,6 +225,75 @@ TEST(GraphicsInterfaceTest, InvalidRendererReportsInvalid)
 {
     FakeRenderer renderer(false);
     EXPECT_FALSE(renderer.IsValid());
+}
+
+// ─── DrawTextureAnchored ────────────────────────────────────────────────────
+
+TEST(DrawTextureAnchoredTest, DefaultAnchor_ReproducesPlainDrawTexture)
+{
+    FakeRenderer renderer(true);
+    FakeTexture texture;
+
+    asge::math::Rect const src{4.0F, 8.0F, 16.0F, 24.0F};
+    asge::math::Rect const dest{100.0F, 200.0F, 32.0F, 48.0F};
+
+    DrawTextureAnchored(renderer, texture, src, dest);
+
+    EXPECT_EQ(renderer.s_DrawTextureSrcDestCalls, 1);
+    EXPECT_FLOAT_EQ(renderer.s_LastDestRect.x, dest.x);
+    EXPECT_FLOAT_EQ(renderer.s_LastDestRect.y, dest.y);
+    EXPECT_FLOAT_EQ(renderer.s_LastDestRect.w, dest.w);
+    EXPECT_FLOAT_EQ(renderer.s_LastDestRect.h, dest.h);
+}
+
+TEST(DrawTextureAnchoredTest, CenterAnchor_OffsetsDestRectByHalfItsSize)
+{
+    FakeRenderer renderer(true);
+    FakeTexture texture;
+
+    asge::math::Rect const src{0.0F, 0.0F, 16.0F, 16.0F};
+    asge::math::Rect const dest{100.0F, 200.0F, 40.0F, 20.0F};
+
+    DrawTextureAnchored(renderer, texture, src, dest, asge::math::Float2{0.5F, 0.5F});
+
+    EXPECT_FLOAT_EQ(renderer.s_LastDestRect.x, 80.0F);  // 100 - 0.5*40
+    EXPECT_FLOAT_EQ(renderer.s_LastDestRect.y, 190.0F); // 200 - 0.5*20
+    EXPECT_FLOAT_EQ(renderer.s_LastDestRect.w, 40.0F);
+    EXPECT_FLOAT_EQ(renderer.s_LastDestRect.h, 20.0F);
+}
+
+TEST(DrawTextureAnchoredTest, BottomRightAnchor_OffsetsDestRectByItsFullSize)
+{
+    FakeRenderer renderer(true);
+    FakeTexture texture;
+
+    asge::math::Rect const src{0.0F, 0.0F, 16.0F, 16.0F};
+    asge::math::Rect const dest{100.0F, 200.0F, 40.0F, 20.0F};
+
+    DrawTextureAnchored(renderer, texture, src, dest, asge::math::Float2{1.0F, 1.0F});
+
+    EXPECT_FLOAT_EQ(renderer.s_LastDestRect.x, 60.0F);  // 100 - 40
+    EXPECT_FLOAT_EQ(renderer.s_LastDestRect.y, 180.0F); // 200 - 20
+    EXPECT_FLOAT_EQ(renderer.s_LastDestRect.w, 40.0F);
+    EXPECT_FLOAT_EQ(renderer.s_LastDestRect.h, 20.0F);
+}
+
+TEST(DrawTextureAnchoredTest, SrcRectIsPassedThroughUnchanged)
+{
+    // Only destRect is transformed by the anchor -- the source crop itself
+    // (e.g. a frame's tight alpha-content bounds) must reach DrawTexture as-is.
+    FakeRenderer renderer(true);
+    FakeTexture texture;
+
+    asge::math::Rect const src{4.0F, 8.0F, 16.0F, 24.0F};
+    asge::math::Rect const dest{100.0F, 200.0F, 32.0F, 48.0F};
+
+    DrawTextureAnchored(renderer, texture, src, dest, asge::math::Float2{0.5F, 1.0F});
+
+    EXPECT_FLOAT_EQ(renderer.s_LastSrcRect.x, src.x);
+    EXPECT_FLOAT_EQ(renderer.s_LastSrcRect.y, src.y);
+    EXPECT_FLOAT_EQ(renderer.s_LastSrcRect.w, src.w);
+    EXPECT_FLOAT_EQ(renderer.s_LastSrcRect.h, src.h);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Fixes #48. `IRenderer::DrawTexture(srcRect, destRect)` linearly maps `srcRect` onto `destRect` with no anchor/pivot concept. A caller fitting frames whose tight alpha-content crop (see #46) varies in size frame to frame into a fixed on-screen box, by centering `destRect`, ends up centering each frame's own differently-sized bounding box instead of one stable reference point — visibly shifting or snapping the character sideways whenever crop size changes.

## Changes

- **`src/ASGE/Video/Graphics/Renderer.hpp`** — added a free function `DrawTextureAnchored(IRenderer const&, ITexture const&, math::Rect const& inSrcRect, math::Rect const& inDestRect, math::Float2 const& inSrcAnchor = {0,0})`. It reinterprets `inDestRect`'s `(x, y)` as the screen position where `inSrcAnchor`'s normalized point within `inSrcRect` should land (rather than `inDestRect`'s top-left corner), then delegates to the existing `DrawTexture(srcRect, destRect)` pure virtual with an offset `destRect`. Default anchor `{0,0}` reproduces the current behavior exactly. Implemented as a coordinate-transform wrapper over the existing pure virtual rather than a new virtual method, so no rendering backend (current or future — see the roadmap's OpenGL/Vulkan/DirectX plans) needs to implement anything new.
- **`tests/unit/Video/GraphicsInterfaceTests.cpp`** — extended the existing `FakeRenderer` fake to capture the last `srcRect`/`destRect` it was called with, and added a `DrawTextureAnchoredTest` suite (4 cases): default anchor reproduces plain `DrawTexture`, `{0.5,0.5}` centers, `{1,1}` anchors the bottom-right corner, and `srcRect` is always passed through unchanged (only `destRect` is transformed).

## Testing

- `cmake --build --preset windows-debug --target ASGE_VideoTests` — builds clean
- `ASGE_VideoTests.exe --gtest_filter="DrawTextureAnchoredTest.*:GraphicsInterfaceTest.*"` — 8/8 passed
- `cmake --build --preset windows-debug` (full project) — builds clean
- `ctest --preset windows-debug` — 705/705 passed (701 baseline + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
