### PR TITLE
feat(rendering): Add layer-based draw ordering to RenderSystem

### DIFF
--- a/docs/roadmap/beyond-the-roadmap.md
+++ b/docs/roadmap/beyond-the-roadmap.md
@@ -38,7 +38,7 @@ Nothing anywhere covers playing back a spritesheet — a walk cycle, an
 idle/attack state switch. [Rendering Primitives](phase-1/02.1-rendering-primitives.md)
 gives static textures only.
 
-## 3. Trigger/sensor colliders and collision layers
+## 3. Trigger/sensor colliders and collision layers - ✅ complete
 
 Checked all three [Physics](phase-1/07.1-physics-system.md) phase docs — CCD,
 raycasts, a character controller

--- a/docs/roadmap/phase-1/10.1-rendering-system.md
+++ b/docs/roadmap/phase-1/10.1-rendering-system.md
@@ -5,14 +5,16 @@ See [README](../README.md). Other phases: [Phase 2](../phase-2/10.2-rendering-sy
 (`SDL_GPU` decision gate, shaders, materials).*
 
 ## Goals
-Camera control and fixed-function compositing effects (tint, glow, fade) on top of
-the 2D primitives from [02-Rendering Primitives](02.1-rendering-primitives.md) —
-the MVP-appropriate slice of "rendering system", with zero backend risk since it's
-built entirely on `SDLRenderer`'s existing render-target/color-mod/blend-mode
-support. Not a 3D pipeline: no mesh renderer, no PBR, no ray tracing.
+Camera control, layer-ordered draw submission, and fixed-function compositing
+effects (tint, glow, fade) on top of the 2D primitives from
+[02-Rendering Primitives](02.1-rendering-primitives.md) — the MVP-appropriate
+slice of "rendering system", with zero backend risk since it's built entirely on
+`SDLRenderer`'s existing render-target/color-mod/blend-mode support. Not a 3D
+pipeline: no mesh renderer, no PBR, no ray tracing.
 
 ## Current state
-Not started. No blockers, but deprioritized behind
+Layer-based draw ordering is done (see Tasks below). Camera control and
+compositing effects are not started, and remain deprioritized behind
 [03-ECS](03.1-entity-component-system.md) and [04-Input](04.1-input-system.md) — an
 MVP needs entities and input before it needs camera zoom or a glow effect.
 
@@ -23,12 +25,25 @@ replaces it. Compositing effects (tint, additive glow, fade) reuse
 needing shader work — proving out several "shader-ish" effects before
 [Phase 2](../phase-2/10.2-rendering-system.md) even asks whether real shaders are worth it.
 
+Layer ordering is submission-order sorting, not a render-target/compositing
+concern: `RenderSystem` collects one `DrawItem` per drawable `(Transform, Sprite)`
+pair, sorts the batch by `Sprite::m_Layer` first, then — only where either item
+opts into `Sprite::m_YSort` — by the sprite's bottom-edge Y (painter's algorithm
+for 2D depth within a layer), then by entity index for a stable order among ties,
+and draws in that order. No z-buffer, no separate render passes per layer — a
+single `SDL_Renderer` pass with sorted submission is enough for a 2D engine.
+
 ## Tasks
+- [x] Layer-based draw ordering: `Sprite::m_Layer` (explicit draw-order bucket) +
+      `Sprite::m_YSort` (optional per-sprite opt-in to sort by vertical position
+      within a layer, for top-down/isometric depth); `RenderSystem` sorts a
+      `DrawItem` batch before submitting draw calls
 - [ ] 2D camera (position, zoom, rotation applied to `DrawX` calls)
 - [ ] Render-target compositing helpers (tint, additive glow, fade) on the existing
       `SDL_Renderer` backend — no shader work required
 
 ## Deliverables
+- `Sprite::m_Layer` / `Sprite::m_YSort` + a sorting `RenderSystem` (done)
 - `IRenderer` extended with camera-aware draw calls
 - Compositing helper API for tint/glow/fade built on the current backend
 

--- a/src/ASGE/Game/Components/Sprite.hpp
+++ b/src/ASGE/Game/Components/Sprite.hpp
@@ -5,6 +5,7 @@
 #include <ASGE/Core/Strings.hpp>
 #include <ASGE/Video/Graphics/Texture.hpp>
 #include <ASGE/Core/Math/Math.hpp>
+#include "Transform.hpp"
 #include "Serialize.hpp"
 
 namespace asge::game::components
@@ -26,10 +27,38 @@ namespace asge::game::components
  */
 struct Sprite
 {
-    video::ITexture* m_Texture{nullptr};      // Non-owning; nullptr means "not drawn"
-    std::optional<math::Rect> m_SourceRect{}; // Sub-region to draw; nullopt = whole texture
-    std::string m_VirtualPath{};              // VFS path m_Texture was (or will be) loaded from
+    video::ITexture*            m_Texture{nullptr}; // Non-owning; nullptr means "not drawn"
+    std::optional<math::Rect>   m_SourceRect{};     // Sub-region to draw; nullopt = whole texture
+    std::string                 m_VirtualPath{};    // VFS path m_Texture was (or will be) loaded from
+    int                         m_Layer{0};         // Draw-order bucket; higher layers draw on top
+    bool                        m_YSort{false};     // Opt into sorting by bottom-edge Y within the layer
 };
+
+inline std::optional<math::Rect> 
+SpriteGetDstRect( Sprite const& inSprite, Transform const& inT ) noexcept
+{
+    if ( !inSprite.m_Texture ) return std::nullopt;
+
+    auto const& texture = *inSprite.m_Texture;
+    auto const& srcRect = inSprite.m_SourceRect;
+    float srcW{}, srcH{};
+
+    if ( srcRect.has_value() )
+    {
+        srcW = srcRect->w;
+        srcH = srcRect->h;
+    }
+    else
+    {
+        math::Int2 const texSize = texture.Size();
+        srcW = static_cast<float>(texSize.x());
+        srcH = static_cast<float>(texSize.y());
+    }
+
+    return math::Rect{ 
+        inT.m_X, inT.m_Y, srcW * inT.m_ScaleX, srcH * inT.m_ScaleY
+    };
+}
 
 template<>
 struct Serializer<Sprite>
@@ -53,6 +82,9 @@ struct Serializer<Sprite>
                   .Set("w", inSprite.m_SourceRect->w)
                   .Set("h", inSprite.m_SourceRect->h);
         }
+
+        sprite.Set("m_Layer", inSprite.m_Layer);
+        sprite.Set("m_YSort", inSprite.m_YSort);
     }
 
     static T FromToml( asge::config::TOMLTableView inEnttView ) noexcept
@@ -72,6 +104,9 @@ struct Serializer<Sprite>
                 rect.Get("h", 0.0f)
             };
         }
+
+        result.m_Layer = sprite.Get( "m_Layer", int{0} );
+        result.m_YSort = sprite.Get( "m_YSort", false );
 
         return result;
     }

--- a/src/ASGE/Game/Systems/RenderSystem.cpp
+++ b/src/ASGE/Game/Systems/RenderSystem.cpp
@@ -1,46 +1,80 @@
 #include "RenderSystem.hpp"
 
-void asge::game::systems::RenderSystem(ecs::Registry &inRegistry, video::IRenderer &inRenderer) noexcept
+#include <vector>
+#include <algorithm>
+
+namespace
 {
+
+using namespace asge;
+
+/** @brief One drawable entity's precomputed sort keys and destination rect for a single frame. */
+struct DrawItem
+{
+    ecs::Entity                        m_Entity;    // Source entity; index is the tie-break of last resort
+    game::components::Transform const* m_Transform;
+    game::components::Sprite const*    m_Sprite;
+    int                                m_Layer;     // Copied from Sprite::m_Layer
+    float                              m_SortY;     // Bottom edge (position.y + drawn height), for y-sort
+    bool                               m_YSort;     // Copied from Sprite::m_YSort
+    math::Rect                         m_DstRect;
+};
+
+/** @brief Orders DrawItems by layer, then bottom-edge Y when either side opts into y-sort, then entity index. */
+bool operator<(DrawItem const& a, DrawItem const& b) noexcept
+{
+    if (a.m_Layer != b.m_Layer) return a.m_Layer < b.m_Layer;
+    if (a.m_YSort || b.m_YSort)
+    {
+        if (a.m_SortY != b.m_SortY) return a.m_SortY < b.m_SortY;
+    }
+    return a.m_Entity.m_Index < b.m_Entity.m_Index;
+}
+
+/** @brief Builds a DrawItem from an entity's Transform + Sprite, or nullopt if the sprite has no texture. */
+std::optional<DrawItem> ConstructFrom(
+    ecs::Entity inE, game::components::Transform const& inT,
+    game::components::Sprite const& inS
+) noexcept {
+    auto const& result = game::components::SpriteGetDstRect( inS, inT );
+    if ( !result.has_value() ) return std::nullopt;
+    return DrawItem
+    {
+        inE, &inT, &inS, inS.m_Layer, inT.m_Y + (*result).h,
+        inS.m_YSort, *result
+    };
+}
+
+}
+
+void asge::game::systems::RenderSystem(
+    ecs::Registry &inRegistry, video::IRenderer &inRenderer) noexcept
+{
+    std::vector<DrawItem> drawItems;
+
     for ( auto [ entity, transform, sprite ]
             : inRegistry.View<components::Transform, components::Sprite>() )
     {
-        (void)entity;
+        if ( auto item = ConstructFrom( entity, transform.get(), sprite.get() ); item.has_value() )
+        {
+            drawItems.push_back( *item );
+        }
+    }
 
-        video::ITexture* texture = sprite.get().m_Texture;
-        if ( !texture ) continue;
+    std::sort( drawItems.begin(), drawItems.end());
 
-        auto const& t = transform.get();
-        auto const& src = sprite.get().m_SourceRect;
-
-        float srcW{};
-        float srcH{};
+    for ( auto const& drawItem : drawItems )
+    {
+        video::ITexture* texture = drawItem.m_Sprite->m_Texture;
+        auto const& src = drawItem.m_Sprite->m_SourceRect;
 
         if ( src.has_value() )
         {
-            srcW = src->w;
-            srcH = src->h;
+            inRenderer.DrawTexture( *texture, *src, drawItem.m_DstRect );
         }
         else
         {
-            math::Int2 const texSize = texture->Size();
-            srcW = static_cast<float>(texSize.x());
-            srcH = static_cast<float>(texSize.y());
-        }
-
-        math::Rect const destRect{
-            t.m_X, t.m_Y,
-            srcW * t.m_ScaleX,
-            srcH * t.m_ScaleY
-        };
-
-        if ( src.has_value() )
-        {
-            inRenderer.DrawTexture( *texture, *src, destRect );
-        }
-        else
-        {
-            inRenderer.DrawTexture( *texture, destRect );
+            inRenderer.DrawTexture( *texture, drawItem.m_DstRect );
         }
     }
 }

--- a/src/ASGE/Game/Systems/RenderSystem.hpp
+++ b/src/ASGE/Game/Systems/RenderSystem.hpp
@@ -19,6 +19,13 @@ namespace asge::game::systems
  * IRenderer's Rect-based DrawTexture overloads (the only ones that also
  * support a source rect) don't take one; use DrawTextureAffine directly
  * for a rotating, unclipped sprite.
+ *
+ * Draw order is sorted, not insertion order: entities are batched by
+ * Sprite::m_Layer first (lower layers draw first, so higher layers draw on
+ * top); within a layer, entities where either side has Sprite::m_YSort set
+ * are further ordered by the sprite's bottom edge (position.y + drawn
+ * height) for a 2D painter's-algorithm depth effect; anything still tied
+ * falls back to entity index for a stable order.
  */
 void RenderSystem( ecs::Registry& inRegistry, video::IRenderer& inRenderer ) noexcept;
 

--- a/tests/unit/Game/RenderSystemTests.cpp
+++ b/tests/unit/Game/RenderSystemTests.cpp
@@ -175,6 +175,153 @@ TEST(RenderSystemTest, SourceRectAndFullTextureEntities_EachDestRectComputedInde
     }
 }
 
+// ─── RenderSystem — layer ordering ──────────────────────────────────────────────
+
+TEST(RenderSystemTest, Layer_LowerLayerDrawnBeforeHigherLayer)
+{
+    Registry registry;
+    FakeTexture texture(asge::math::Int2{ 10, 10 });
+    RecordingRenderer renderer;
+
+    auto high = registry.CreateEntity();
+    ASSERT_TRUE(high.IsOk());
+    ASSERT_TRUE(registry.AddComponent(high.Value(),
+        Transform{ .m_X = 100.0f, .m_Y = 0.0f }).IsOk());
+    ASSERT_TRUE(registry.AddComponent(high.Value(),
+        Sprite{ .m_Texture = &texture, .m_Layer = 5 }).IsOk());
+
+    auto low = registry.CreateEntity();
+    ASSERT_TRUE(low.IsOk());
+    ASSERT_TRUE(registry.AddComponent(low.Value(),
+        Transform{ .m_X = 200.0f, .m_Y = 0.0f }).IsOk());
+    ASSERT_TRUE(registry.AddComponent(low.Value(),
+        Sprite{ .m_Texture = &texture, .m_Layer = 1 }).IsOk());
+
+    asge::game::systems::RenderSystem(registry, renderer);
+
+    ASSERT_EQ(renderer.m_Calls.size(), 2u);
+    // Layer 1 (low) must draw before layer 5 (high) regardless of creation order.
+    EXPECT_FLOAT_EQ(renderer.m_Calls[0].m_DestRect.x, 200.0f);
+    EXPECT_FLOAT_EQ(renderer.m_Calls[1].m_DestRect.x, 100.0f);
+}
+
+// ─── RenderSystem — y-sort within a layer ───────────────────────────────────────
+
+TEST(RenderSystemTest, YSort_SortsByBottomEdgeWithinSameLayer)
+{
+    Registry registry;
+    FakeTexture texture(asge::math::Int2{ 10, 10 }); // Fixed 10-tall, so bottom edge = y + 10
+    RecordingRenderer renderer;
+
+    auto front = registry.CreateEntity(); // Higher on screen -> lower bottom edge -> drawn first
+    ASSERT_TRUE(front.IsOk());
+    ASSERT_TRUE(registry.AddComponent(front.Value(),
+        Transform{ .m_X = 2.0f, .m_Y = 10.0f }).IsOk());
+    ASSERT_TRUE(registry.AddComponent(front.Value(),
+        Sprite{ .m_Texture = &texture, .m_YSort = true }).IsOk());
+
+    auto back = registry.CreateEntity(); // Created first, but lower on screen -> drawn last
+    ASSERT_TRUE(back.IsOk());
+    ASSERT_TRUE(registry.AddComponent(back.Value(),
+        Transform{ .m_X = 1.0f, .m_Y = 100.0f }).IsOk());
+    ASSERT_TRUE(registry.AddComponent(back.Value(),
+        Sprite{ .m_Texture = &texture, .m_YSort = true }).IsOk());
+
+    asge::game::systems::RenderSystem(registry, renderer);
+
+    ASSERT_EQ(renderer.m_Calls.size(), 2u);
+    EXPECT_FLOAT_EQ(renderer.m_Calls[0].m_DestRect.x, 2.0f);
+    EXPECT_FLOAT_EQ(renderer.m_Calls[1].m_DestRect.x, 1.0f);
+}
+
+TEST(RenderSystemTest, YSort_TiedBottomEdge_FallsBackToEntityIndex)
+{
+    Registry registry;
+    FakeTexture texture(asge::math::Int2{ 10, 10 });
+    RecordingRenderer renderer;
+
+    auto first = registry.CreateEntity();
+    ASSERT_TRUE(first.IsOk());
+    ASSERT_TRUE(registry.AddComponent(first.Value(),
+        Transform{ .m_X = 1.0f, .m_Y = 10.0f }).IsOk());
+    ASSERT_TRUE(registry.AddComponent(first.Value(),
+        Sprite{ .m_Texture = &texture, .m_YSort = true }).IsOk());
+
+    auto second = registry.CreateEntity();
+    ASSERT_TRUE(second.IsOk());
+    ASSERT_TRUE(registry.AddComponent(second.Value(),
+        Transform{ .m_X = 2.0f, .m_Y = 10.0f }).IsOk()); // Same bottom edge as `first`
+    ASSERT_TRUE(registry.AddComponent(second.Value(),
+        Sprite{ .m_Texture = &texture, .m_YSort = true }).IsOk());
+
+    asge::game::systems::RenderSystem(registry, renderer);
+
+    ASSERT_EQ(renderer.m_Calls.size(), 2u);
+    // Bottom edges tie, so creation order (entity index) decides.
+    EXPECT_FLOAT_EQ(renderer.m_Calls[0].m_DestRect.x, 1.0f);
+    EXPECT_FLOAT_EQ(renderer.m_Calls[1].m_DestRect.x, 2.0f);
+}
+
+TEST(RenderSystemTest, YSort_MixedWithNonYSortSprite_EitherOptingInSortsBothByY)
+{
+    Registry registry;
+    FakeTexture texture(asge::math::Int2{ 10, 10 });
+    RecordingRenderer renderer;
+
+    // Created first, no y-sort, but sits lower on screen (larger bottom edge).
+    auto plain = registry.CreateEntity();
+    ASSERT_TRUE(plain.IsOk());
+    ASSERT_TRUE(registry.AddComponent(plain.Value(),
+        Transform{ .m_X = 1.0f, .m_Y = 100.0f }).IsOk());
+    ASSERT_TRUE(registry.AddComponent(plain.Value(),
+        Sprite{ .m_Texture = &texture, .m_YSort = false }).IsOk());
+
+    // Created second, opts into y-sort, and sits higher on screen.
+    auto sorted = registry.CreateEntity();
+    ASSERT_TRUE(sorted.IsOk());
+    ASSERT_TRUE(registry.AddComponent(sorted.Value(),
+        Transform{ .m_X = 2.0f, .m_Y = 10.0f }).IsOk());
+    ASSERT_TRUE(registry.AddComponent(sorted.Value(),
+        Sprite{ .m_Texture = &texture, .m_YSort = true }).IsOk());
+
+    asge::game::systems::RenderSystem(registry, renderer);
+
+    ASSERT_EQ(renderer.m_Calls.size(), 2u);
+    // Either side opting into y-sort is enough to order the pair by bottom
+    // edge -- creation order alone (which would put `plain` first) is not used.
+    EXPECT_FLOAT_EQ(renderer.m_Calls[0].m_DestRect.x, 2.0f);
+    EXPECT_FLOAT_EQ(renderer.m_Calls[1].m_DestRect.x, 1.0f);
+}
+
+TEST(RenderSystemTest, NoYSort_SameLayer_PreservesEntityCreationOrderRegardlessOfY)
+{
+    Registry registry;
+    FakeTexture texture(asge::math::Int2{ 10, 10 });
+    RecordingRenderer renderer;
+
+    // Created first but sits lower on screen than `second` -- without
+    // y-sort, creation order must win, not vertical position.
+    auto first = registry.CreateEntity();
+    ASSERT_TRUE(first.IsOk());
+    ASSERT_TRUE(registry.AddComponent(first.Value(),
+        Transform{ .m_X = 1.0f, .m_Y = 100.0f }).IsOk());
+    ASSERT_TRUE(registry.AddComponent(first.Value(),
+        Sprite{ .m_Texture = &texture }).IsOk());
+
+    auto second = registry.CreateEntity();
+    ASSERT_TRUE(second.IsOk());
+    ASSERT_TRUE(registry.AddComponent(second.Value(),
+        Transform{ .m_X = 2.0f, .m_Y = 10.0f }).IsOk());
+    ASSERT_TRUE(registry.AddComponent(second.Value(),
+        Sprite{ .m_Texture = &texture }).IsOk());
+
+    asge::game::systems::RenderSystem(registry, renderer);
+
+    ASSERT_EQ(renderer.m_Calls.size(), 2u);
+    EXPECT_FLOAT_EQ(renderer.m_Calls[0].m_DestRect.x, 1.0f);
+    EXPECT_FLOAT_EQ(renderer.m_Calls[1].m_DestRect.x, 2.0f);
+}
+
 // ─── RenderSystem — null texture ────────────────────────────────────────────────
 
 TEST(RenderSystemTest, NullTexture_EntitySkipped)


### PR DESCRIPTION
Sprite gains m_Layer (an explicit draw-order bucket; higher layers draw on top) and m_YSort (opt-in per-sprite sort by vertical position within a layer, for top-down/isometric depth), both round-tripping through TOML alongside the existing fields. RenderSystem no longer just iterates the (Transform, Sprite) view and draws in whatever order the registry hands entities back — it now collects one DrawItem per drawable pair, sorts the batch by layer first, then by bottom-edge Y wherever either item opts into y-sort, then by entity index as a stable tie-break, and submits draw calls in that order. No z-buffer or extra render passes: a single SDL_Renderer pass with sorted submission is enough for a 2D engine.

Doc comments cover the new fields and the sort itself; RenderSystemTests.cpp gains five cases (lower-layer-first, y-sort by bottom edge, tied-bottom-edge falls back to entity index, a y-sort sprite pulling a non-y-sort sprite into Y order, plain insertion order preserved when neither opts in). Cross-referenced from the Phase 1 rendering-system roadmap doc, which previously only tracked camera control and compositing effects. Also marks Physics's "Trigger/sensor colliders and collision layers" item complete in beyond-the-roadmap.md, reflecting CollisionLayer filtering already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)