### PR TITLE
feat(game): Let a game state request a clean Application quit

### DIFF
--- a/src/ASGE/Application/Application.hpp
+++ b/src/ASGE/Application/Application.hpp
@@ -68,7 +68,11 @@ public:
         m_Game.emplace( m_VideoSys.GetRenderer(), std::forward<Args>(inGameArgs)... );
     }
 
-    /** @brief Runs the main loop (poll events, update, render, present) until a quit event arrives. */
+    /**
+     * @brief Runs the main loop (poll events, update, render, present) until
+     *        an OS quit event arrives or a state requests one via
+     *        TransitionKind::Quit.
+     */
     void Run()
     {
         if ( !m_Game ) { LOG_ERROR("Application failed to initialize -- video system init failed"); return; }
@@ -87,6 +91,13 @@ public:
             }
 
             m_Game->Update( time::DeltaTime(), m_InputSys.GetState() );
+
+            if ( m_Game->QuitRequested() )
+            {
+                LOG_DEBUG("Application quit requested by game state");
+                m_Running = false;
+            }
+
             m_Game->Render( m_VideoSys.GetRenderer() );
             m_VideoSys.GetRenderer().Present();
         }

--- a/src/ASGE/Game/Game.hpp
+++ b/src/ASGE/Game/Game.hpp
@@ -33,6 +33,9 @@ public:
 
     /** @brief Called for every system event Application's loop pumps. */
     virtual void OnSystemEvent(event::SystemEvent const& inSysEvent) = 0;
+
+    /** @brief True once a state has requested a clean shutdown via TransitionKind::Quit. */
+    [[nodiscard]] virtual bool QuitRequested() const noexcept = 0;
 };
 
 }
@@ -64,6 +67,7 @@ protected:
 private:
     state::GameStateStack<TStateId>                          m_States;
     std::unordered_map<TStateId, std::unique_ptr<StateType>> m_StateCache;
+    bool                                                      m_QuitRequested{false};
 
     /** @brief Returns inId's cached state, creating it via CreateState() on first use. */
     StateType& GetOrCreateState( TStateId inId )
@@ -76,7 +80,10 @@ private:
         return *it->second;
     }
 
-    /** @brief Applies one state's requested Push/Pop/Replace to m_States; TransitionKind::None is a no-op. */
+    /**
+     * @brief Applies one state's requested Push/Pop/Replace to m_States, or
+     *        flags a Quit for QuitRequested(); TransitionKind::None is a no-op.
+     */
     void ApplyTransition( Transition const& inTransition )
     {
         switch ( inTransition.m_Kind )
@@ -87,6 +94,8 @@ private:
 
         case state::TransitionKind::Replace:
             m_States.ReplaceRaw( &GetOrCreateState( inTransition.m_TargetId ) ); return;
+
+        case state::TransitionKind::Quit: m_QuitRequested = true; return;
 
         default: return;
         }
@@ -137,6 +146,8 @@ public:
     {
         m_States.OnSystemEvent( inSysEvent );
     }
+
+    [[nodiscard]] bool QuitRequested() const noexcept override { return m_QuitRequested; }
 };
 
 /** @brief Detects (via derived-to-base conversion) whether TDerived derives from some Game<T>. */

--- a/src/ASGE/Game/States/GameState.hpp
+++ b/src/ASGE/Game/States/GameState.hpp
@@ -8,14 +8,21 @@
 namespace asge::game::state
 {
 
-/** @brief What a state Update() is asking GameStateStack to do to the stack. */
-enum class TransitionKind { None, Push, Pop, Replace };
+/**
+ * @brief What a state Update() is asking for -- a stack change, or a clean
+ *        application shutdown.
+ *
+ * Quit isn't a stack operation: GameStateStack forwards it through
+ * unmodified, and Game<TStateId>::ApplyTransition is what actually acts on
+ * it, by flagging the request for Application to observe via QuitRequested().
+ */
+enum class TransitionKind { None, Push, Pop, Replace, Quit };
 
-/** @brief One requested stack change: push/replace a new state, or pop the current one. */
+/** @brief One requested stack change (or quit): push/replace a new state, or pop/quit the current one. */
 template<typename TStateId>
 struct Transition
 {
-    TStateId        m_TargetId; // Ignored when m_Kind == Pop
+    TStateId        m_TargetId; // Ignored when m_Kind == Pop or Quit
     TransitionKind  m_Kind;
 };
 

--- a/tests/unit/Game/GameStateStackTests.cpp
+++ b/tests/unit/Game/GameStateStackTests.cpp
@@ -184,6 +184,17 @@ TEST_F(GameStateStackTest, Update_NonBlockingTopState_LowerStatesTransitionIsUse
     EXPECT_EQ(m_B.m_UpdateCount, 1);
 }
 
+TEST_F(GameStateStackTest, Update_QuitTransition_ForwardedUnmodified)
+{
+    m_A.m_NextTransition = Transition<int>{ 0, TransitionKind::Quit };
+    m_Stack.PushRaw(&m_A);
+
+    auto result = m_Stack.Update(0.016f, m_Input);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->m_Kind, TransitionKind::Quit);
+}
+
 // ─── Render ──────────────────────────────────────────────────────────────────
 
 TEST_F(GameStateStackTest, Render_EmptyStack_NoStatesRendered)

--- a/tests/unit/Game/GameTests.cpp
+++ b/tests/unit/Game/GameTests.cpp
@@ -167,6 +167,39 @@ TEST_F(GameTest, Update_ReplaceTransition_ExitsOldEntersNewAtSameDepth)
     EXPECT_EQ(m_Game.m_Created[0]->m_EventCount, 0);
 }
 
+// ─── QuitRequested ────────────────────────────────────────────────────────────
+
+TEST_F(GameTest, QuitRequested_FreshGame_IsFalse)
+{
+    EXPECT_FALSE(m_Game.QuitRequested());
+}
+
+TEST_F(GameTest, Update_QuitTransition_SetsQuitRequestedTrue)
+{
+    m_Game.SetInitialState(0);
+    m_Game.m_Created[0]->m_NextTransition = Transition<int>{ 0, TransitionKind::Quit };
+
+    m_Game.Update(0.016f, m_Input);
+
+    EXPECT_TRUE(m_Game.QuitRequested());
+}
+
+TEST_F(GameTest, NonQuitTransitions_NeverSetQuitRequested)
+{
+    m_Game.SetInitialState(0);
+    m_Game.m_Created[0]->m_NextTransition = Transition<int>{ 1, TransitionKind::Push };
+    m_Game.Update(0.016f, m_Input);
+    EXPECT_FALSE(m_Game.QuitRequested());
+
+    m_Game.m_Created[1]->m_NextTransition = Transition<int>{ 2, TransitionKind::Replace };
+    m_Game.Update(0.016f, m_Input);
+    EXPECT_FALSE(m_Game.QuitRequested());
+
+    m_Game.m_Created[2]->m_NextTransition = Transition<int>{ 0, TransitionKind::Pop };
+    m_Game.Update(0.016f, m_Input);
+    EXPECT_FALSE(m_Game.QuitRequested());
+}
+
 // ─── State caching ────────────────────────────────────────────────────────────
 
 TEST_F(GameTest, GetOrCreateState_SameIdReusedAcrossPopAndPushAgain)


### PR DESCRIPTION
## Summary

Fixes #62.

`Application::Run()`'s loop only ever cleared `m_Running` in response to an OS-level `QuitEvent` — neither `IGame`/`Game<TStateId>` nor `IGameState`/`Transition` exposed any way for a state to ask for a shutdown. The only workaround was calling `std::exit()` directly from a state (e.g. an "Exit Game" button handler), which skips every destructor between that call and process exit — `Application`, `VideoSystem`, `AssetManager`-held textures, etc.

## Approach

Went with the issue's second suggested option (a new `TransitionKind`) over the callback-injection option, since it fits the existing "a state returns a `Transition`, `Game` applies it" architecture with no API-breaking changes:

- `TransitionKind::Quit` added alongside `None`/`Push`/`Pop`/`Replace`.
- It isn't a stack operation — `GameStateStack::Update()` needed no changes at all; it already forwards whatever `Transition` the topmost state returns, unmodified.
- `Game<TStateId>::ApplyTransition` handles `Quit` by setting a new `m_QuitRequested` flag instead of touching the state stack.
- `IGame`/`Game<TStateId>` expose the flag via a new `QuitRequested() const noexcept`.
- `Application<TGame>::Run()` checks it right after each `Update()` call and clears `m_Running`, mirroring exactly how the existing `QuitEvent` path already does — so the same one-more-frame-then-stop behavior applies to both quit sources.

A state now asks for a clean shutdown the same way it asks for any other transition:
```cpp
return Transition<TStateId>{ .m_Kind = TransitionKind::Quit };
```
going through the normal loop exit and every destructor along the way, instead of `std::exit()`.

**No constructor signatures change** — fully backward compatible, every existing example builds unmodified.

## Changes

- `src/ASGE/Game/States/GameState.hpp` — `TransitionKind::Quit`, updated doc comments.
- `src/ASGE/Game/Game.hpp` — `IGame::QuitRequested()`, `Game<TStateId>::m_QuitRequested`/`QuitRequested()`, `ApplyTransition` handles `Quit`.
- `src/ASGE/Application/Application.hpp` — `Run()` checks `QuitRequested()` after `Update()`.
- `tests/unit/Game/GameStateStackTests.cpp` — `Quit` forwarded through `Update()` unmodified.
- `tests/unit/Game/GameTests.cpp` — fresh `Game` starts with `QuitRequested() == false`; a `Quit` transition sets it `true`; `None`/`Push`/`Replace`/`Pop` never set it.
- `Application<TGame>` itself needs a live SDL window to construct, so isn't practically unit-testable — the existing `ApplicationTests.cpp` compile-check fixture (`template class asge::Application<CompileCheckGame>;`) already forces the compiler to type-check the changed `Run()` body; no changes needed there.

## Testing

- `ctest --preset windows-debug` — full suite, 812/812 passing.
- `ASGE_GameTests` run standalone (Game + GameStateStack suites) — 25/25 passing.
- Full build including every example (`cmake --build --preset windows-debug`) — all still compile unmodified, confirming the backward-compatibility claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)