### PR TITLE
feat(game): Add DebugDrawColliders for visualizing Collider bounds

### DIFF
--- a/src/ASGE/CMakeLists.txt
+++ b/src/ASGE/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(ASGE STATIC
 
     # Gameplay systems built on top of the ECS
     Game/Systems/PhysicsSystem.cpp
+    Game/Systems/PhysicsDebugSystem.cpp
     Game/Systems/RenderSystem.cpp
 
     # Asset Manager

--- a/src/ASGE/Game/Systems.hpp
+++ b/src/ASGE/Game/Systems.hpp
@@ -1,4 +1,5 @@
 #pragma once
 
 #include "Systems/PhysicsSystem.hpp"
+#include "Systems/PhysicsDebugSystem.hpp"
 #include "Systems/RenderSystem.hpp"

--- a/src/ASGE/Game/Systems/PhysicsDebugSystem.cpp
+++ b/src/ASGE/Game/Systems/PhysicsDebugSystem.cpp
@@ -1,0 +1,55 @@
+#include "PhysicsDebugSystem.hpp"
+#include "PhysicsSystem.hpp"
+
+#include <ASGE/Core/Media/Color.hpp>
+
+namespace
+{
+
+/** @brief The outline color DebugDrawColliders uses for one ResolutionType. */
+asge::media::RGBA_Color ColorForResolution( asge::game::components::ResolutionType inResolution ) noexcept
+{
+    using asge::game::components::ResolutionType;
+    switch ( inResolution )
+    {
+    case ResolutionType::Solid:   return { 0, 255, 0, 255 };
+    case ResolutionType::Trigger: return { 255, 255, 0, 255 };
+    case ResolutionType::Unknown: return { 128, 128, 128, 255 };
+    }
+    return { 128, 128, 128, 255 };
+}
+
+}
+
+void asge::game::systems::DebugDrawColliders( ecs::Registry& inRegistry, video::IRenderer& inRenderer ) noexcept
+{
+    for ( auto [ entity, transform, collider ]
+            : inRegistry.View<components::Transform, components::Collider>() )
+    {
+        (void)entity;
+
+        auto const bounds = WorldBounds( transform.get(), collider.get() );
+        auto const color  = ColorForResolution( collider.get().m_Resolution );
+
+        std::visit( [&inRenderer, &color]( auto const& inShape )
+        {
+            using ShapeT = std::decay_t<decltype(inShape)>;
+
+            if constexpr ( std::is_same_v<ShapeT, math::Rect> )
+            {
+                inRenderer.DrawRect( inShape, color, false );
+            }
+            else
+            {
+                inRenderer.DrawCircle(
+                    math::Int2{
+                        static_cast<int>( inShape.m_Center.x() ),
+                        static_cast<int>( inShape.m_Center.y() )
+                    },
+                    static_cast<int>( inShape.m_Radius ),
+                    color, false
+                );
+            }
+        }, bounds );
+    }
+}

--- a/src/ASGE/Game/Systems/PhysicsDebugSystem.hpp
+++ b/src/ASGE/Game/Systems/PhysicsDebugSystem.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <ASGE/Core/ECS/Registry.hpp>
+#include <ASGE/Video/Graphics/Renderer.hpp>
+#include <ASGE/Game/Components/Transform.hpp>
+#include <ASGE/Game/Components/Collider.hpp>
+
+namespace asge::game::systems
+{
+
+/**
+ * @brief Draws every Collider's world-space bounds — Rect via DrawRect,
+ *        Circle via DrawCircle, both unfilled — color-coded by
+ *        ResolutionType (green Solid, yellow Trigger, grey Unknown) so a
+ *        mixed scene reads at a glance which colliders actually push out
+ *        versus just sense.
+ *
+ * Purely opt-in: nothing in the physics/render pipeline calls this on its
+ * own, a game calls it from its own Render() (typically behind its own
+ * debug toggle) the same as any other system.
+ */
+void DebugDrawColliders( ecs::Registry& inRegistry, video::IRenderer& inRenderer ) noexcept;
+
+}

--- a/src/ASGE/Game/Systems/PhysicsSystem.cpp
+++ b/src/ASGE/Game/Systems/PhysicsSystem.cpp
@@ -14,30 +14,6 @@ using namespace asge::game::components;
 using namespace asge::ecs;
 using namespace asge::math;
 
-/** @brief inC's local shape offset by inT's position, in world space — same shape kind, new coordinates. */
-ColliderShape WorldBounds( Transform const& inT, Collider const& inC ) noexcept
-{
-    return std::visit([&inT]( auto const& inShape ) -> ColliderShape
-    {
-        using ShapeT = std::decay_t<decltype(inShape)>;
-
-        if constexpr ( std::is_same_v<ShapeT, asge::math::Rect> )
-        {
-            return asge::math::Rect{
-                inT.m_X + inShape.x, inT.m_Y + inShape.y,
-                inShape.w, inShape.h
-            };
-        } else {
-            return asge::math::Circle{
-                asge::math::Float2{ 
-                    inT.m_X + inShape.m_Center.x(), inT.m_Y + inShape.m_Center.y() 
-                },
-                inShape.m_Radius
-            };
-        }
-    }, inC.m_LocalBounds);
-}
-
 // Applies a positional correction and zeroes velocity on whichever axis moved.
 void ApplyCorrection( Transform& inT, Velocity& inV, asge::math::Float2 const& inDelta ) noexcept
 {
@@ -94,6 +70,30 @@ void ResolveSolidCollision(
             t2, vel2.Value().get(), { -mtv.x() * share2, -mtv.y() * share2 } );
     }
 }
+}
+
+asge::game::components::ColliderShape asge::game::systems::WorldBounds(
+    components::Transform const& inTransform, components::Collider const& inCollider ) noexcept
+{
+    return std::visit([&inTransform]( auto const& inShape ) -> components::ColliderShape
+    {
+        using ShapeT = std::decay_t<decltype(inShape)>;
+
+        if constexpr ( std::is_same_v<ShapeT, math::Rect> )
+        {
+            return math::Rect{
+                inTransform.m_X + inShape.x, inTransform.m_Y + inShape.y,
+                inShape.w, inShape.h
+            };
+        } else {
+            return math::Circle{
+                math::Float2{
+                    inTransform.m_X + inShape.m_Center.x(), inTransform.m_Y + inShape.m_Center.y()
+                },
+                inShape.m_Radius
+            };
+        }
+    }, inCollider.m_LocalBounds);
 }
 
 void asge::game::systems::MovementSystem(ecs::Registry &inRegistry, float inDeltaTime) noexcept

--- a/src/ASGE/Game/Systems/PhysicsSystem.hpp
+++ b/src/ASGE/Game/Systems/PhysicsSystem.hpp
@@ -1,4 +1,4 @@
-#pragma once 
+#pragma once
 
 #include <set>
 #include <vector>
@@ -6,9 +6,18 @@
 #include <ASGE/Core/ECS/Entity.hpp>
 #include <ASGE/Core/ECS/Registry.hpp>
 #include <ASGE/Core/Math/Math.hpp>
+#include <ASGE/Game/Components/Transform.hpp>
+#include <ASGE/Game/Components/Collider.hpp>
 
 namespace asge::game::systems
 {
+
+/**
+ * @brief inCollider's local shape offset by inTransform's position, in
+ *        world space — same shape kind, new coordinates.
+ */
+components::ColliderShape WorldBounds(
+    components::Transform const& inTransform, components::Collider const& inCollider ) noexcept;
 
 /**
  * @brief Cross-frame bookkeeping PhysicsUpdate needs — currently just which

--- a/tests/unit/Game/CMakeLists.txt
+++ b/tests/unit/Game/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(ASGE_GameTests
     RenderSystemTests.cpp
     PhysicsSystemTests.cpp
+    PhysicsDebugSystemTests.cpp
     GameStateStackTests.cpp
     GameTests.cpp
 )

--- a/tests/unit/Game/PhysicsDebugSystemTests.cpp
+++ b/tests/unit/Game/PhysicsDebugSystemTests.cpp
@@ -1,0 +1,179 @@
+#include <ASGE/Game/Systems/PhysicsDebugSystem.hpp>
+#include <ASGE/Core/ECS/Registry.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace
+{
+
+using asge::ecs::Entity;
+using asge::ecs::Registry;
+using asge::game::components::Collider;
+using asge::game::components::ResolutionType;
+using asge::game::components::Transform;
+
+// IRenderer stub recording every DrawRect/DrawCircle call it receives, so
+// tests can assert on DebugDrawColliders' shape/color choices without a
+// real window/GPU.
+class RecordingRenderer final : public asge::video::IRenderer
+{
+public:
+    struct RectCall   { asge::math::Rect m_Rect; asge::media::RGBA_Color m_Color; bool m_Fill; };
+    struct CircleCall { asge::math::Int2 m_Center; int m_Radius; asge::media::RGBA_Color m_Color; bool m_Fill; };
+
+    mutable std::vector<RectCall>   m_RectCalls;
+    mutable std::vector<CircleCall> m_CircleCalls;
+
+    void Clear(asge::media::RGBA_Color const&) const override {}
+
+    void DrawRect(asge::math::Rect const& inRect,
+        asge::media::RGBA_Color const& inColor, bool inFill) const override
+    {
+        m_RectCalls.push_back({ inRect, inColor, inFill });
+    }
+
+    void DrawLine(asge::math::Float2 const&, asge::math::Float2 const&,
+        asge::media::RGBA_Color const&) const override {}
+
+    void DrawCircle(asge::math::Int2 const& inCenter, int inRadius,
+        asge::media::RGBA_Color const& inColor, bool inFill) const override
+    {
+        m_CircleCalls.push_back({ inCenter, inRadius, inColor, inFill });
+    }
+
+    void DrawTexture(asge::video::ITexture const&, asge::math::Rect const&) const noexcept override {}
+    void DrawTexture(asge::video::ITexture const&, asge::math::Float2 const&) const noexcept override {}
+    void DrawTexture(asge::video::ITexture const&, asge::math::Rect const&,
+        asge::math::Rect const&) const noexcept override {}
+    void DrawTexture9Grid(asge::video::ITexture const&, float, float, float, float,
+        asge::math::Rect const&) const noexcept override {}
+    void DrawTextureTiled(asge::video::ITexture const&, float, asge::math::Rect const&) const noexcept override {}
+    void DrawTextureAffine(asge::video::ITexture const&, asge::math::Float2 const&,
+        asge::math::Float2 const&, asge::math::Float2 const&) const noexcept override {}
+    void DrawString(asge::str::StringView, asge::media::Font const&, asge::video::ITexture&,
+        asge::math::Float2 const&, asge::media::RGBA_Color const&) const noexcept override {}
+
+    void Present() const override {}
+    [[nodiscard]] std::unique_ptr<asge::video::ITexture> CreateTexture(
+        asge::media::Image const&) const noexcept override { return nullptr; }
+    [[nodiscard]] bool IsValid() const override { return true; }
+};
+
+Entity MakeRectCollider(Registry& inRegistry, float inX, float inY,
+    ResolutionType inResolution = ResolutionType::Solid)
+{
+    auto entity = inRegistry.CreateEntity();
+    EXPECT_TRUE(entity.IsOk());
+    EXPECT_TRUE(inRegistry.AddComponent(entity.Value(), Transform{ .m_X = inX, .m_Y = inY }).IsOk());
+    EXPECT_TRUE(inRegistry.AddComponent(entity.Value(), Collider{
+        .m_LocalBounds = asge::math::Rect{ 5.0f, 6.0f, 30.0f, 40.0f },
+        .m_Resolution = inResolution
+    }).IsOk());
+    return entity.Value();
+}
+
+// ─── DebugDrawColliders — shape dispatch ────────────────────────────────────
+
+TEST(PhysicsDebugSystemTest, RectCollider_DrawsUnfilledRectAtWorldOffsetBounds)
+{
+    Registry registry;
+    RecordingRenderer renderer;
+    MakeRectCollider(registry, 10.0f, 20.0f);
+
+    asge::game::systems::DebugDrawColliders(registry, renderer);
+
+    ASSERT_EQ(renderer.m_RectCalls.size(), 1u);
+    EXPECT_TRUE(renderer.m_CircleCalls.empty());
+    auto const& call = renderer.m_RectCalls[0];
+    EXPECT_FALSE(call.m_Fill);
+    EXPECT_FLOAT_EQ(call.m_Rect.x, 15.0f); // 10 + 5
+    EXPECT_FLOAT_EQ(call.m_Rect.y, 26.0f); // 20 + 6
+    EXPECT_FLOAT_EQ(call.m_Rect.w, 30.0f);
+    EXPECT_FLOAT_EQ(call.m_Rect.h, 40.0f);
+}
+
+TEST(PhysicsDebugSystemTest, CircleCollider_DrawsUnfilledCircleAtWorldOffsetCenter)
+{
+    Registry registry;
+    RecordingRenderer renderer;
+
+    auto entity = registry.CreateEntity();
+    ASSERT_TRUE(entity.IsOk());
+    ASSERT_TRUE(registry.AddComponent(entity.Value(), Transform{ .m_X = 10.0f, .m_Y = 20.0f }).IsOk());
+    ASSERT_TRUE(registry.AddComponent(entity.Value(), Collider{
+        .m_LocalBounds = asge::math::Circle{ asge::math::Float2{ 5.0f, 6.0f }, 8.0f }
+    }).IsOk());
+
+    asge::game::systems::DebugDrawColliders(registry, renderer);
+
+    ASSERT_EQ(renderer.m_CircleCalls.size(), 1u);
+    EXPECT_TRUE(renderer.m_RectCalls.empty());
+    auto const& call = renderer.m_CircleCalls[0];
+    EXPECT_FALSE(call.m_Fill);
+    EXPECT_EQ(call.m_Center.x(), 15); // 10 + 5
+    EXPECT_EQ(call.m_Center.y(), 26); // 20 + 6
+    EXPECT_EQ(call.m_Radius, 8);
+}
+
+TEST(PhysicsDebugSystemTest, EmptyRegistry_DrawsNothing)
+{
+    Registry registry;
+    RecordingRenderer renderer;
+
+    asge::game::systems::DebugDrawColliders(registry, renderer);
+
+    EXPECT_TRUE(renderer.m_RectCalls.empty());
+    EXPECT_TRUE(renderer.m_CircleCalls.empty());
+}
+
+// ─── DebugDrawColliders — color by ResolutionType ───────────────────────────
+
+void ExpectColor(asge::media::RGBA_Color const& inColor,
+    std::uint8_t inR, std::uint8_t inG, std::uint8_t inB, std::uint8_t inA)
+{
+    EXPECT_EQ(inColor.r, inR);
+    EXPECT_EQ(inColor.g, inG);
+    EXPECT_EQ(inColor.b, inB);
+    EXPECT_EQ(inColor.a, inA);
+}
+
+TEST(PhysicsDebugSystemTest, SolidResolution_DrawsGreen)
+{
+    Registry registry;
+    RecordingRenderer renderer;
+    MakeRectCollider(registry, 0.0f, 0.0f, ResolutionType::Solid);
+
+    asge::game::systems::DebugDrawColliders(registry, renderer);
+
+    ASSERT_EQ(renderer.m_RectCalls.size(), 1u);
+    ExpectColor(renderer.m_RectCalls[0].m_Color, 0, 255, 0, 255);
+}
+
+TEST(PhysicsDebugSystemTest, TriggerResolution_DrawsYellow)
+{
+    Registry registry;
+    RecordingRenderer renderer;
+    MakeRectCollider(registry, 0.0f, 0.0f, ResolutionType::Trigger);
+
+    asge::game::systems::DebugDrawColliders(registry, renderer);
+
+    ASSERT_EQ(renderer.m_RectCalls.size(), 1u);
+    ExpectColor(renderer.m_RectCalls[0].m_Color, 255, 255, 0, 255);
+}
+
+TEST(PhysicsDebugSystemTest, UnknownResolution_DrawsGrey)
+{
+    Registry registry;
+    RecordingRenderer renderer;
+    MakeRectCollider(registry, 0.0f, 0.0f, ResolutionType::Unknown);
+
+    asge::game::systems::DebugDrawColliders(registry, renderer);
+
+    ASSERT_EQ(renderer.m_RectCalls.size(), 1u);
+    ExpectColor(renderer.m_RectCalls[0].m_Color, 128, 128, 128, 255);
+}
+
+}

--- a/tests/unit/Game/PhysicsSystemTests.cpp
+++ b/tests/unit/Game/PhysicsSystemTests.cpp
@@ -50,6 +50,37 @@ void RunCollisionResolution(Registry& inRegistry, PhysicsState& inState)
     asge::game::systems::DispatchTriggerEvents(inState, contacts);
 }
 
+// ─── WorldBounds ─────────────────────────────────────────────────────────────
+
+TEST(PhysicsSystemTest, WorldBounds_RectCollider_OffsetByTransformPosition)
+{
+    Transform t{ .m_X = 10.0f, .m_Y = 20.0f };
+    Collider c{ .m_LocalBounds = asge::math::Rect{ 5.0f, 6.0f, 30.0f, 40.0f } };
+
+    auto bounds = asge::game::systems::WorldBounds( t, c );
+
+    ASSERT_TRUE( std::holds_alternative<asge::math::Rect>( bounds ) );
+    auto const& rect = std::get<asge::math::Rect>( bounds );
+    EXPECT_FLOAT_EQ( rect.x, 15.0f ); // 10 + 5
+    EXPECT_FLOAT_EQ( rect.y, 26.0f ); // 20 + 6
+    EXPECT_FLOAT_EQ( rect.w, 30.0f ); // shape size is untouched
+    EXPECT_FLOAT_EQ( rect.h, 40.0f );
+}
+
+TEST(PhysicsSystemTest, WorldBounds_CircleCollider_CenterOffsetByTransformPosition)
+{
+    Transform t{ .m_X = 10.0f, .m_Y = 20.0f };
+    Collider c{ .m_LocalBounds = asge::math::Circle{ asge::math::Float2{ 5.0f, 6.0f }, 8.0f } };
+
+    auto bounds = asge::game::systems::WorldBounds( t, c );
+
+    ASSERT_TRUE( std::holds_alternative<asge::math::Circle>( bounds ) );
+    auto const& circle = std::get<asge::math::Circle>( bounds );
+    EXPECT_FLOAT_EQ( circle.m_Center.x(), 15.0f ); // 10 + 5
+    EXPECT_FLOAT_EQ( circle.m_Center.y(), 26.0f ); // 20 + 6
+    EXPECT_FLOAT_EQ( circle.m_Radius, 8.0f );      // radius is untouched
+}
+
 // ─── CollisionResolution — both entities movable ────────────────────────────
 
 TEST(PhysicsSystemTest, TwoOverlappingMovableEntities_PushedApartEvenlyOnLeastPenetrationAxis)


### PR DESCRIPTION
## Summary

Fixes #63.

There was no built-in way to see `Collider` bounds at render time — a game could hand-roll it (iterate `Registry::View<Transform, Collider>()`, resolve each `Collider`'s local shape against its `Transform`, call `DrawRect`/`DrawCircle` unfilled), but that's boilerplate every game built on the physics system ends up writing for itself, for something that's squarely a physics-debugging convenience rather than game logic.

## What's added

`asge::game::systems::DebugDrawColliders(Registry&, IRenderer&)` — purely opt-in, matching the issue's suggested shape exactly:

```cpp
void DebugDrawColliders(ecs::Registry& inRegistry, video::IRenderer& inRenderer) noexcept;
```

A game calls it (or doesn't) from its own `Render()`, same as any other system — nothing engine-side wires it into `PhysicsUpdate` or adds a "debug mode" flag anywhere.

Draws each `Collider`'s world-space bounds unfilled — `Rect` via `DrawRect`, `Circle` via `DrawCircle` — color-coded by `ResolutionType` as the issue suggested: green for `Solid`, yellow for `Trigger`, grey for `Unknown`, so a mixed scene reads at a glance which colliders actually push out versus just sense.

## Implementation note

`WorldBounds` (the `Transform`+`Collider`-local-bounds offset math) already existed as an anonymous-namespace helper inside `PhysicsSystem.cpp`, used internally by `DetectCollisions`. Rather than duplicate that math in the new file, I promoted it to a declared function in `asge::game::systems` (`PhysicsSystem.hpp`), so both `DetectCollisions` and `DebugDrawColliders` share one implementation. `DetectCollisions`' own behavior is unchanged — it now just calls the newly-public version of the exact same function.

## Changes

- `src/ASGE/Game/Systems/PhysicsDebugSystem.hpp`/`.cpp` — the new system.
- `src/ASGE/Game/Systems/PhysicsSystem.hpp`/`.cpp` — `WorldBounds` promoted from an anonymous-namespace helper to a declared, documented function.
- `src/ASGE/Game/Systems.hpp`, `src/ASGE/CMakeLists.txt` — new file registered alongside the existing systems.
- `tests/unit/Game/PhysicsSystemTests.cpp` — new coverage for `WorldBounds` itself (Rect and Circle, each offset correctly by a non-zero `Transform` position) now that it's public/testable.
- `tests/unit/Game/PhysicsDebugSystemTests.cpp` — new file: `DebugDrawColliders` draws the right shape at the right offset for Rect/Circle, draws nothing for an empty registry, and picks the right color for each `ResolutionType`.

## Testing

- `ctest --preset windows-debug` — full suite, 823/823 passing.
- `ASGE_GameTests` run standalone — 69/69 passing, including the 8 new tests.
- Full build including every example — confirms `WorldBounds`' promotion didn't change `DetectCollisions`' behavior anywhere it's used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)